### PR TITLE
docs: easy to copy

### DIFF
--- a/docs/onboarding/setup/02_macOS_Homebrew.md
+++ b/docs/onboarding/setup/02_macOS_Homebrew.md
@@ -4,8 +4,8 @@
 
 ## Command Line Tools をインストール
 
-```
-% xcode-select --install
+```Bash
+xcode-select --install
 ```
 
 ## [Homebrew](https://brew.sh/ja/) とは
@@ -14,16 +14,20 @@ macOS のためのパッケージ管理ツールです。
 
 ## Homebrew をインストール
 
-```
-% /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```Bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ```
 
+```Bash
+echo 'eval $(/opt/homebrew/bin/brew shellenv)' >> ~/.zprofile
 ```
-% echo 'eval $(/opt/homebrew/bin/brew shellenv)' >> ~/.zprofile
+```Bash
 % eval $(/opt/homebrew/bin/brew shellenv)
 ```
 
+```Bash
+brew -v
 ```
-% brew -v
+```
 Homebrew X.X.X
 ```


### PR DESCRIPTION
# 概要

- 02_macOS_Homebrew.mdをコピーがしやすいように変更した。
    - コマンドの％を消した
    - コマンドごとに分けた

# 関連する issue
なし
- Close #

# 確認方法・見てほしいところ
1. 既存の内容はコマンドをコピーしようとすると％までコピーするという問題があった。そのため％を消し、入力する必要があるコマンドであることをわかってもらえるように、macOSの場合はBash、Windowsの場合はPowerShellのように言語識別子を追加した


# コメント

-
