### PR TITLE
[Android] スワイプジェスチャでPopするとクラッシュする

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -212,7 +212,11 @@ final class _BasePageState extends ConsumerState<BasePage> {
         if (didPop) {
           return;
         }
-        Navigator.of(context).pop();
+        final navigator = Navigator.of(context);
+        final shouldPop =
+            !((await tabNavigatorKeyMaps[tabItem]?.currentState?.maybePop()) ??
+                true);
+        if (shouldPop && navigator.canPop()) navigator.pop();
       },
       child: Scaffold(
         resizeToAvoidBottomInset: false,


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

# 概要

<!--1行程度で完結に-->

AndroidでスワイプジェスチャでPopするとクラッシュする問題を修正

# やったこと

<!--詳細はネストして記述-->
<!--完了したもののみチェックを入れる-->

- [x] PopScope の onPopInvokedWithResult クロージャを修正
  - [cfd0783](https://github.com/fun-dotto/dotto/commit/cfd078347b7800b57e46e336691df24edef7d4d3#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20d) でデグレした可能性あり

# 関連する Issue

- Close #331 

# 確認したこと

<!--CIワークフローで確認できること以外で確認したこと-->
<!--完了したもののみチェックを入れる-->

- [x] 動作確認

<!-- I want to review in Japanese. -->
