### PR TITLE
feat: ホーム画面のカードにテキスト挿入

### DIFF
--- a/lib/feature/funch/widget/funch_mypage_card.dart
+++ b/lib/feature/funch/widget/funch_mypage_card.dart
@@ -157,6 +157,10 @@ final class FunchMyPageCard extends ConsumerWidget {
               error: (error, stackTrace) => _buildEmptyCard(context, date),
               loading: () => Shimmer(child: Container(color: Colors.grey)),
             ),
+            const Text(
+              'メニューは変更される可能性があります',
+              style: TextStyle(fontSize: 12, color: Colors.black54),
+            ),
           ],
         ),
       ),


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

# 概要
- テキスト挿入
<!--1行程度で完結に-->

# やったこと

<!--詳細はネストして記述-->
<!--完了したもののみチェックを入れる-->

- [x] ホーム画面の学食カードにテキスト挿入

# 関連する Issue

- Close #379 

# 確認したこと
- [x] 実行できること
- [x] デバッグでテキストが表示されていること

<!--CIワークフローで確認できること以外で確認したこと-->
<!--完了したもののみチェックを入れる-->


# UI 差分

|           Before           |           After            |
| :------------------------: | :------------------------: |
| <img src="" width="200" /> | <img src="" width="200" /> |

# コメント

- 実際にメニューが表示されている時にどのように表示されるのかは未確認です
   -  [funch-admin-web](https://github.com/fun-dotto/funch-admin-web)のセットアップができなく、ダミーデータを用意できなかったため

# メモ

-

<!-- I want to review in Japanese. -->
