### PR TITLE
SettingScreen から GitHubContributorScreen に遷移するように変更

### DIFF
--- a/lib/feature/setting/settings.dart
+++ b/lib/feature/setting/settings.dart
@@ -212,7 +212,7 @@ final class SettingsScreen extends ConsumerWidget {
               ),
               // Contributors表示
               SettingsTile.navigation(
-                title: const Text('開発者一覧'),
+                title: const Text('開発者'),
                 leading: const Icon(Icons.person),
                 onPressed: (_) {
                   Navigator.of(context).push(


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

# 概要
設定画面から開発者一覧に遷移するように変更

<!--1行程度で完結に-->

# やったこと

<!--詳細はネストして記述-->
<!--完了したもののみチェックを入れる-->

- [x] SettingScreen から GitHubContributorScreen に遷移するように変更

# 関連する Issue

- Close #389 

# 確認したこと

<!--CIワークフローで確認できること以外で確認したこと-->
<!--完了したもののみチェックを入れる-->

- [x] 設定画面に開発者一覧のタイルがあること
- [x] 開発者一覧のタイルを押すとGitHubContributorScreenに遷移する

# UI 差分

|           Before           |           After            |
| :------------------------: | :------------------------: |
| <img src="https://github.com/user-attachments/assets/67bcf44b-0ab5-4347-b190-e8114d97022c" width="200" /> |<img src="https://github.com/user-attachments/assets/0c36f97e-c64a-46b6-a68a-f13a349b6265" width="200" /> |


# コメント

- 画面遷移は完璧です！！お願いします🙇

# メモ

-

<!-- I want to review in Japanese. -->
