### PR TITLE
Settings: ログイン/ログアウト表示を更新 (#390)

### DIFF
--- a/lib/feature/setting/settings.dart
+++ b/lib/feature/setting/settings.dart
@@ -83,6 +83,10 @@ final class SettingsScreen extends ConsumerWidget {
                     ? (_) => SettingsRepository().onLogin(context, ref, (User? user) => userNotifier.user = user)
                     : (_) => SettingsRepository().onLogout(userNotifier.logout),
               ),
+            ],
+          ),
+          SettingsSection(
+            tiles: <SettingsTile>[
               // 学年
               SettingsTile.navigation(
                 onPressed: (_) async {


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

# やったこと

<!--詳細はネストして記述-->

- Close #390 
  - [x] 未ログイン時の「Google アカウント (@fun.ac.jp)」の記述とそれに対応するログイン時の記述を削除
  - [x] ログインボタンセルのテキストを「ログイン」から「Google アカウント (@fun.ac.jp) でログイン」に変更
  - [x] Figmaのデザイン案を参照し、ログイン時の記述を「ログイン中」から「${user.email}でログイン中」に変更
  - [x] ログイン/ログアウトのセクションと学年からHOPE連携までのセクションを分離

# 確認したこと

<!--CIワークフローで確認できること以外で確認したこと-->

- [x] 未ログイン時に「Google アカウント (@fun.ac.jp) でログイン」と表示され、タップすると Google ログインフローが起動すること
- [x] ログイン時に「{メールアドレス}でログイン中」と表示されること
- [x] ログイン中にタップするとログアウト処理が実行され、再度未ログイン状態（「Google アカウント (@fun.ac.jp) でログイン」表示）に戻ること
- [x] ログイン/ログアウトのセクションと学年からHOPE連携までのセクションが分離して表示されていること

# UI 差分
### 未ログイン時

|           Before           |           After            |
| :------------------------: | :------------------------: |
| <img src="https://github.com/user-attachments/assets/767a8751-6dbf-4fe9-b2ca-786469a447bc" width="200" /> | <img src="https://github.com/user-attachments/assets/e38d866a-e21f-4af9-9988-c9a0fa6ceb65" width="200" /> |


### ログイン時
|           Before           |           After            |
| :------------------------: | :------------------------: |
| <img src="https://github.com/user-attachments/assets/1790bd07-8414-4119-ae84-0855bba201cc" width="200" /> | <img src="https://github.com/user-attachments/assets/394e314f-02dd-49af-bd4b-9cf56a2620c7" width="200" /> |

<!-- I want to review in Japanese. -->
