### PR TITLE
UseCaseからRiverpodへの依存を削除

### DIFF
--- a/lib/feature/github_contributor/github_contributor_service.dart
+++ b/lib/feature/github_contributor/github_contributor_service.dart
@@ -1,14 +1,13 @@
 import 'package:dotto/domain/github_profile.dart';
 import 'package:dotto/repository/github_contributor_repository.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 final class GitHubContributorService {
-  GitHubContributorService(this.ref);
+  GitHubContributorService(this.gitHubContributorRepository);
 
-  final Ref ref;
+  final GitHubContributorRepository gitHubContributorRepository;
 
   Future<List<GitHubProfile>> getContributors() async {
-    final contributors = await ref.read(gitHubContributorRepositoryProvider).getContributors();
+    final contributors = await gitHubContributorRepository.getContributors();
     contributors.sort((a, b) => b.contributions.compareTo(a.contributions));
     return contributors;
   }

--- a/lib/feature/github_contributor/github_contributor_viewmodel.dart
+++ b/lib/feature/github_contributor/github_contributor_viewmodel.dart
@@ -1,8 +1,14 @@
 import 'package:dotto/feature/github_contributor/github_contributor_service.dart';
 import 'package:dotto/feature/github_contributor/github_contributor_viewstate.dart';
+import 'package:dotto/repository/github_contributor_repository.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'github_contributor_viewmodel.g.dart';
+
+final gitHubContributorRepositoryProvider = Provider<GitHubContributorRepository>(
+  (_) => GitHubContributorRepositoryImpl(),
+);
 
 @riverpod
 final class GitHubContributorViewModel extends _$GitHubContributorViewModel {
@@ -10,7 +16,7 @@ final class GitHubContributorViewModel extends _$GitHubContributorViewModel {
 
   @override
   Future<GitHubContributorViewState> build() async {
-    _service = GitHubContributorService(ref);
+    _service = GitHubContributorService(ref.read(gitHubContributorRepositoryProvider));
     final contributors = await _service.getContributors();
     return GitHubContributorViewState(contributors: contributors);
   }

--- a/lib/repository/github_contributor_repository.dart
+++ b/lib/repository/github_contributor_repository.dart
@@ -2,11 +2,6 @@ import 'package:dio/dio.dart';
 import 'package:dotto/domain/github_profile.dart';
 import 'package:dotto/repository/model/github_profile_response.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-
-final gitHubContributorRepositoryProvider = Provider<GitHubContributorRepository>(
-  (_) => GitHubContributorRepositoryImpl(),
-);
 
 //
 // ignore: one_member_abstracts

--- a/test/feature/github_contributors/github_contributor_service_test.dart
+++ b/test/feature/github_contributors/github_contributor_service_test.dart
@@ -1,15 +1,11 @@
 import 'package:dotto/domain/github_profile.dart';
 import 'package:dotto/feature/github_contributor/github_contributor_service.dart';
 import 'package:dotto/repository/github_contributor_repository.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 
 import 'github_contributor_service_test.mocks.dart';
-
-/// テスト用の GitHubContributorService Provider
-final GitHubContributorServiceProvider = Provider<GitHubContributorService>(GitHubContributorService.new);
 
 @GenerateMocks([GitHubContributorRepository])
 void main() {
@@ -32,10 +28,6 @@ void main() {
     ),
   ];
 
-  ProviderContainer createContainer() => ProviderContainer(
-    overrides: [gitHubContributorRepositoryProvider.overrideWithValue(githubContributorRepository)],
-  );
-
   setUp(() {
     reset(githubContributorRepository);
   });
@@ -44,8 +36,7 @@ void main() {
     test('getContributors がGitHubプロフィール一覧を正しく取得する', () async {
       when(githubContributorRepository.getContributors()).thenAnswer((_) async => testGitHubProfiles);
 
-      final container = createContainer();
-      final service = container.read(GitHubContributorServiceProvider);
+      final service = GitHubContributorService(githubContributorRepository);
 
       final result = await service.getContributors();
 
@@ -64,8 +55,7 @@ void main() {
     test('getContributors が空のリストを正しく取得する', () async {
       when(githubContributorRepository.getContributors()).thenAnswer((_) async => <GitHubProfile>[]);
 
-      final container = createContainer();
-      final service = container.read(GitHubContributorServiceProvider);
+      final service = GitHubContributorService(githubContributorRepository);
 
       final result = await service.getContributors();
 
@@ -79,8 +69,7 @@ void main() {
     test('getContributors がリポジトリの例外をそのまま伝播する', () async {
       when(githubContributorRepository.getContributors()).thenThrow(Exception('Failed to get contributors'));
 
-      final container = createContainer();
-      final service = container.read(GitHubContributorServiceProvider);
+      final service = GitHubContributorService(githubContributorRepository);
 
       expect(() => service.getContributors(), throwsA(isA<Exception>()));
 


### PR DESCRIPTION
<!-- GitHub Copilot コードレビューへの指示: このプルリクエストをレビューしてコメントするときは日本語でお願いします -->

# やったこと

<!--詳細はネストして記述-->

- UseCaseからRiverpodへの依存を削除

# メモ

- こうすれば、Riverpodへの依存をPresentation Layerだけに留められる
