### PR TITLE
リリース/デバッグのデフォルト付きAPI環境オーバーライドを追加

### DIFF
--- a/lib/api/api_environment.dart
+++ b/lib/api/api_environment.dart
@@ -7,28 +7,55 @@ part 'api_environment.g.dart';
 
 @Riverpod(keepAlive: true)
 final class ApiEnvironment extends _$ApiEnvironment {
+  Environment? _environmentOverride;
+
   @override
   Environment build() {
-    if (kReleaseMode) return Environment.production;
-    return Environment.staging;
+    return _effectiveEnvironment;
   }
+
+  Environment get defaultEnvironment => kReleaseMode ? Environment.production : Environment.staging;
+
+  Environment get _effectiveEnvironment => _environmentOverride ?? defaultEnvironment;
 
   Environment get value => state;
 
-  set value(Environment newValue) {
-    state = newValue;
-    _save();
-  }
+  Environment? get environmentOverride => _environmentOverride;
 
-  Future<void> load() async {
-    final environment = await UserPreferenceRepository.getString(UserPreferenceKeys.environment);
-    if (environment != null) {
-      state = Environment.values.firstWhere((e) => e.tag == environment, orElse: () => state);
+  Future<void> setOverride({required Environment? value}) async {
+    _environmentOverride = value;
+    if (value == null) {
+      await UserPreferenceRepository.remove(UserPreferenceKeys.apiEnvironmentOverride);
+    } else {
+      await UserPreferenceRepository.setString(UserPreferenceKeys.apiEnvironmentOverride, value.tag);
     }
+    state = _effectiveEnvironment;
   }
 
-  Future<void> _save() async {
-    await UserPreferenceRepository.setString(UserPreferenceKeys.environment, state.tag);
+  Future<void> loadOverride() async {
+    final overrideTag = await UserPreferenceRepository.getString(UserPreferenceKeys.apiEnvironmentOverride);
+    if (overrideTag != null) {
+      _environmentOverride = Environment.values.firstWhere(
+        (environment) => environment.tag == overrideTag,
+        orElse: () => defaultEnvironment,
+      );
+      state = _effectiveEnvironment;
+      return;
+    }
+
+    final legacyTag = await UserPreferenceRepository.getString(UserPreferenceKeys.environment);
+    if (legacyTag == null) {
+      state = _effectiveEnvironment;
+      return;
+    }
+
+    _environmentOverride = Environment.values.firstWhere(
+      (environment) => environment.tag == legacyTag,
+      orElse: () => defaultEnvironment,
+    );
+    await UserPreferenceRepository.setString(UserPreferenceKeys.apiEnvironmentOverride, _environmentOverride!.tag);
+    await UserPreferenceRepository.remove(UserPreferenceKeys.environment);
+    state = _effectiveEnvironment;
   }
 }
 

--- a/lib/domain/user_preference_keys.dart
+++ b/lib/domain/user_preference_keys.dart
@@ -1,5 +1,6 @@
 enum UserPreferenceKeys {
   environment(key: 'environment', type: String),
+  apiEnvironmentOverride(key: 'apiEnvironmentOverride', type: String),
   grade(key: 'grade', type: String),
   course(key: 'course', type: String),
   class_(key: 'class', type: String),

--- a/lib/feature/debug/debug_screen.dart
+++ b/lib/feature/debug/debug_screen.dart
@@ -17,6 +17,8 @@ final class DebugScreen extends HookConsumerWidget {
     final appCheckToken = useFuture(useMemoized(() => FirebaseAppCheck.instance.getToken()));
     final idToken = useFuture(useMemoized(() => FirebaseAuth.instance.currentUser?.getIdToken()));
     final environment = ref.watch(apiEnvironmentProvider);
+    final apiEnvironmentNotifier = ref.read(apiEnvironmentProvider.notifier);
+    final environmentOverride = apiEnvironmentNotifier.environmentOverride;
     final config = ref.watch(configProvider);
     final configNotifier = ref.read(configProvider.notifier);
     final isV2EnabledOverride = configNotifier.isV2EnabledOverride;
@@ -27,17 +29,35 @@ final class DebugScreen extends HookConsumerWidget {
     Future<void> showEnvironmentPicker() async {
       await showDialog<void>(
         context: context,
-        builder: (context) => SimpleDialog(
-          title: const Text('Environment'),
-          children: Environment.values.map((env) {
-            return MaterialButton(
-              onPressed: () {
-                ref.read(apiEnvironmentProvider.notifier).value = env;
-                Navigator.of(context).pop();
+        builder: (dialogContext) => SimpleDialog(
+          title: const Text('API Environment Override'),
+          children: [
+            SimpleDialogOption(
+              onPressed: () async {
+                Navigator.of(dialogContext).pop();
+                await apiEnvironmentNotifier.setOverride(value: null);
               },
-              child: ListTile(title: Text(env.label), trailing: Icon(env == environment ? Icons.check : null)),
-            );
-          }).toList(),
+              child: ListTile(
+                contentPadding: EdgeInsets.zero,
+                title: const Text('Use Default'),
+                subtitle: Text('Default: ${apiEnvironmentNotifier.defaultEnvironment.label}'),
+                trailing: environmentOverride == null ? const Icon(Icons.check) : null,
+              ),
+            ),
+            ...Environment.values.map((env) {
+              return SimpleDialogOption(
+                onPressed: () async {
+                  Navigator.of(dialogContext).pop();
+                  await apiEnvironmentNotifier.setOverride(value: env);
+                },
+                child: ListTile(
+                  contentPadding: EdgeInsets.zero,
+                  title: Text('Force ${env.label}'),
+                  trailing: environmentOverride == env ? const Icon(Icons.check) : null,
+                ),
+              );
+            }),
+          ],
         ),
       );
     }
@@ -179,9 +199,12 @@ final class DebugScreen extends HookConsumerWidget {
             ),
           ),
           ListTile(
-            title: const Text('Environment'),
-            subtitle: Text(environment.label),
-            trailing: const Icon(Icons.chevron_right),
+            title: const Text('API Environment Override'),
+            subtitle: Text(switch (environmentOverride) {
+              null => 'Use Default (${apiEnvironmentNotifier.defaultEnvironment.label})',
+              final value => 'Forced: ${value.label}',
+            }),
+            trailing: Text('Effective: ${environment.label}'),
             onTap: showEnvironmentPicker,
           ),
           ListTile(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -77,7 +77,7 @@ Future<void> main() async {
 
   // アプリの起動
   final container = ProviderContainer();
-  await container.read(apiEnvironmentProvider.notifier).load();
+  await container.read(apiEnvironmentProvider.notifier).loadOverride();
   runApp(UncontrolledProviderScope(container: container, child: const MyApp()));
 }
 


### PR DESCRIPTION
## 概要
- API環境選択を `isV2Enabled` と同様のオーバーライド方式に変更
- オーバーライド未設定時のデフォルトをビルドモードで切り替え
  - Release: Production
  - Debug: Staging
- デバッグ画面から `Use Default` / `Force <Environment>` を選択可能に変更
- 既存の `environment` 設定値を `apiEnvironmentOverride` へ移行する互換処理を追加

## 変更内容
- `ApiEnvironment` を optional override + 有効値解決の実装に変更
- ユーザー設定キーに `apiEnvironmentOverride` を追加
- 起動時の読み込みを `load()` から `loadOverride()` に変更
- デバッグ画面の表示とピッカー動作を override/effective 表示に変更

## 確認
- pre-commit checks 通過
