### PR TITLE
オンボーディングの学食ページ表示をisFunchEnabledで制御

### DIFF
--- a/.github/workflows/danger-flutter-app.yml
+++ b/.github/workflows/danger-flutter-app.yml
@@ -41,6 +41,8 @@ jobs:
         with:
           fetch-depth: 0
       - uses: jdx/mise-action@v3
+        with:
+          working_directory: Flutter
       - name: Install dependencies
         run: bundle install
       - name: Run Danger

--- a/.github/workflows/danger-flutter-app.yml
+++ b/.github/workflows/danger-flutter-app.yml
@@ -37,8 +37,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: jdx/mise-action@v3

--- a/.github/workflows/danger-flutter-app.yml
+++ b/.github/workflows/danger-flutter-app.yml
@@ -42,6 +42,8 @@ jobs:
           fetch-depth: 0
       - uses: jdx/mise-action@v3
         with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          cache: false
           working_directory: Flutter
       - name: Install dependencies
         run: bundle install

--- a/.github/workflows/format-flutter-app.yml
+++ b/.github/workflows/format-flutter-app.yml
@@ -35,9 +35,13 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: jdx/mise-action@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          cache: false
       - name: Install dependencies
         run: task install-all
       - name: Run format

--- a/.github/workflows/format-flutter-app.yml
+++ b/.github/workflows/format-flutter-app.yml
@@ -42,6 +42,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           cache: false
+          working_directory: Flutter
       - name: Install dependencies
         run: task install-all
       - name: Run format

--- a/.github/workflows/format-flutter-app.yml
+++ b/.github/workflows/format-flutter-app.yml
@@ -45,6 +45,8 @@ jobs:
           working_directory: Flutter
       - name: Install dependencies
         run: task install-all
+      - name: Generate code
+        run: task build-all
       - name: Run format
         run: task format
       - name: Check for diff

--- a/.github/workflows/test-flutter-app.yaml
+++ b/.github/workflows/test-flutter-app.yaml
@@ -34,6 +34,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: jdx/mise-action@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-flutter-app.yaml
+++ b/.github/workflows/test-flutter-app.yaml
@@ -40,6 +40,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           cache: false
+          working_directory: Flutter
       - name: Install Dependencies
         run: task install-all
       - name: Run Build

--- a/Flutter/lib/feature/onboarding/domain/onboarding_page.dart
+++ b/Flutter/lib/feature/onboarding/domain/onboarding_page.dart
@@ -5,37 +5,38 @@ class OnboardingPage {
 
   final String title;
 
-  static const pages = <OnboardingPage>[
-    OnboardingWelcomePage(
+  static List<OnboardingPage> pages({required bool isFunchEnabled}) => [
+    const OnboardingWelcomePage(
       title: 'ようこそ',
       bodyTop: 'Dottoで',
       bodyBottom: 'はこだて未来大学のすべてを',
     ),
-    OnboardingContentPage(
+    const OnboardingContentPage(
       title: '時間割の管理',
       description: '自分の時間割を設定して\n休講/補講情報を受け取ろう',
       imagePath: Asset.tutorialTimetableMock,
     ),
-    OnboardingContentPage(
+    const OnboardingContentPage(
       title: 'バスの時刻表',
       description: '大学から最寄りのバス停までの\n時刻表を確認しよう',
       imagePath: Asset.tutorialBusMock,
     ),
-    OnboardingContentPage(
+    const OnboardingContentPage(
       title: '学内マップ',
       description: '空き教室を確認したり\n研究室を検索しよう',
       imagePath: Asset.tutorialCampusMapMock,
     ),
-    OnboardingContentPage(
+    const OnboardingContentPage(
       title: '科目検索',
       description: 'レビューや過去問を\n閲覧しよう',
       imagePath: Asset.tutorialSubjectMock,
     ),
-    OnboardingContentPage(
-      title: '学食メニュー',
-      description: '学食のメニューや価格を\n確認しよう',
-      imagePath: Asset.tutorialCafeteriaMock,
-    ),
+    if (isFunchEnabled)
+      const OnboardingContentPage(
+        title: '学食メニュー',
+        description: '学食のメニューや価格を\n確認しよう',
+        imagePath: Asset.tutorialCafeteriaMock,
+      ),
   ];
 }
 

--- a/Flutter/lib/feature/onboarding/domain/onboarding_page.dart
+++ b/Flutter/lib/feature/onboarding/domain/onboarding_page.dart
@@ -5,39 +5,40 @@ class OnboardingPage {
 
   final String title;
 
-  static List<OnboardingPage> pages({required bool isFunchEnabled}) => [
-    const OnboardingWelcomePage(
-      title: 'ようこそ',
-      bodyTop: 'Dottoで',
-      bodyBottom: 'はこだて未来大学のすべてを',
-    ),
-    const OnboardingContentPage(
-      title: '時間割の管理',
-      description: '自分の時間割を設定して\n休講/補講情報を受け取ろう',
-      imagePath: Asset.tutorialTimetableMock,
-    ),
-    const OnboardingContentPage(
-      title: 'バスの時刻表',
-      description: '大学から最寄りのバス停までの\n時刻表を確認しよう',
-      imagePath: Asset.tutorialBusMock,
-    ),
-    const OnboardingContentPage(
-      title: '学内マップ',
-      description: '空き教室を確認したり\n研究室を検索しよう',
-      imagePath: Asset.tutorialCampusMapMock,
-    ),
-    const OnboardingContentPage(
-      title: '科目検索',
-      description: 'レビューや過去問を\n閲覧しよう',
-      imagePath: Asset.tutorialSubjectMock,
-    ),
-    if (isFunchEnabled)
-      const OnboardingContentPage(
-        title: '学食メニュー',
-        description: '学食のメニューや価格を\n確認しよう',
-        imagePath: Asset.tutorialCafeteriaMock,
-      ),
-  ];
+  static List<OnboardingPage> pages({required bool isFunchEnabled}) =>
+      List.unmodifiable([
+        const OnboardingWelcomePage(
+          title: 'ようこそ',
+          bodyTop: 'Dottoで',
+          bodyBottom: 'はこだて未来大学のすべてを',
+        ),
+        const OnboardingContentPage(
+          title: '時間割の管理',
+          description: '自分の時間割を設定して\n休講/補講情報を受け取ろう',
+          imagePath: Asset.tutorialTimetableMock,
+        ),
+        const OnboardingContentPage(
+          title: 'バスの時刻表',
+          description: '大学から最寄りのバス停までの\n時刻表を確認しよう',
+          imagePath: Asset.tutorialBusMock,
+        ),
+        const OnboardingContentPage(
+          title: '学内マップ',
+          description: '空き教室を確認したり\n研究室を検索しよう',
+          imagePath: Asset.tutorialCampusMapMock,
+        ),
+        const OnboardingContentPage(
+          title: '科目検索',
+          description: 'レビューや過去問を\n閲覧しよう',
+          imagePath: Asset.tutorialSubjectMock,
+        ),
+        if (isFunchEnabled)
+          const OnboardingContentPage(
+            title: '学食メニュー',
+            description: '学食のメニューや価格を\n確認しよう',
+            imagePath: Asset.tutorialCafeteriaMock,
+          ),
+      ]);
 }
 
 final class OnboardingWelcomePage extends OnboardingPage {

--- a/Flutter/lib/feature/onboarding/onboarding_screen.dart
+++ b/Flutter/lib/feature/onboarding/onboarding_screen.dart
@@ -4,8 +4,8 @@ import 'package:dotto/feature/onboarding/domain/onboarding_page.dart';
 import 'package:dotto_design_system/component/button.dart';
 import 'package:dotto_design_system/style/semantic_color.dart';
 import 'package:flutter/material.dart';
-import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 final class OnboardingScreen extends HookConsumerWidget {
   const OnboardingScreen({required this.onDismissed, super.key});

--- a/Flutter/lib/feature/onboarding/onboarding_screen.dart
+++ b/Flutter/lib/feature/onboarding/onboarding_screen.dart
@@ -220,7 +220,7 @@ final class OnboardingScreen extends HookConsumerWidget {
             child: DottoButton(
               onPressed: onNextButtonTapped,
               child: Text(
-                activeIndicatorIndex == indicatorCount ? 'はじめる' : '次へ',
+                activeIndicatorIndex == indicatorCount - 1 ? 'はじめる' : '次へ',
               ),
             ),
           ),
@@ -262,6 +262,19 @@ final class OnboardingScreen extends HookConsumerWidget {
     final pages = OnboardingPage.pages(isFunchEnabled: isFunchEnabled);
     final pageController = usePageController();
     final currentPage = useState(0);
+
+    useEffect(() {
+      if (currentPage.value >= pages.length) {
+        final clamped = pages.length - 1;
+        currentPage.value = clamped;
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (pageController.hasClients) {
+            pageController.jumpToPage(clamped);
+          }
+        });
+      }
+      return null;
+    }, [pages.length]);
 
     return Scaffold(
       appBar: AppBar(title: const Text('Dottoの使い方')),

--- a/Flutter/lib/feature/onboarding/onboarding_screen.dart
+++ b/Flutter/lib/feature/onboarding/onboarding_screen.dart
@@ -1,11 +1,13 @@
 import 'package:dotto/asset.dart';
+import 'package:dotto/controller/config_controller.dart';
 import 'package:dotto/feature/onboarding/domain/onboarding_page.dart';
 import 'package:dotto_design_system/component/button.dart';
 import 'package:dotto_design_system/style/semantic_color.dart';
 import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 
-final class OnboardingScreen extends HookWidget {
+final class OnboardingScreen extends HookConsumerWidget {
   const OnboardingScreen({required this.onDismissed, super.key});
 
   final void Function() onDismissed;
@@ -185,9 +187,10 @@ final class OnboardingScreen extends HookWidget {
 
   Widget _buildBottomArea({
     required int activeIndicatorIndex,
+    required int pageCount,
     required VoidCallback onNextButtonTapped,
   }) {
-    final indicatorCount = OnboardingPage.pages.length - 1;
+    final indicatorCount = pageCount - 1;
 
     return Padding(
       padding: const EdgeInsets.fromLTRB(40, 40, 40, 40),
@@ -252,7 +255,11 @@ final class OnboardingScreen extends HookWidget {
   }
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final isFunchEnabled = ref.watch(
+      configProvider.select((config) => config.isFunchEnabled),
+    );
+    final pages = OnboardingPage.pages(isFunchEnabled: isFunchEnabled);
     final pageController = usePageController();
     final currentPage = useState(0);
 
@@ -270,9 +277,9 @@ final class OnboardingScreen extends HookWidget {
                   child: PageView.builder(
                     controller: pageController,
                     onPageChanged: (index) => currentPage.value = index,
-                    itemCount: OnboardingPage.pages.length,
+                    itemCount: pages.length,
                     itemBuilder: (context, index) {
-                      final page = OnboardingPage.pages[index];
+                      final page = pages[index];
                       if (page is OnboardingWelcomePage) {
                         return _buildWelcomePage(context, page);
                       } else if (page is OnboardingContentPage) {
@@ -287,8 +294,9 @@ final class OnboardingScreen extends HookWidget {
                   activeIndicatorIndex: currentPage.value == 0
                       ? -1
                       : currentPage.value - 1,
+                  pageCount: pages.length,
                   onNextButtonTapped: () async {
-                    if (currentPage.value == OnboardingPage.pages.length - 1) {
+                    if (currentPage.value == pages.length - 1) {
                       onDismissed();
                       return;
                     }

--- a/Flutter/lib/feature/subject/subject_detail_past_exam_screen.dart
+++ b/Flutter/lib/feature/subject/subject_detail_past_exam_screen.dart
@@ -55,7 +55,7 @@ final class SubjectDetailPastExamScreen extends HookWidget {
                     CloudflarePdfViewer(url: url, filename: filename),
                 settings: RouteSettings(
                   // TODO(kantacky): /subjects/${subjectId}/past_exams/${pastExamId} にする
-                  name: '/subjects/${pastExamId}/past_exams/${filename}',
+                  name: '/subjects/$pastExamId/past_exams/$filename',
                 ),
               ),
             );


### PR DESCRIPTION
# 案件

https://www.notion.so/fun-dotto/Remote-Config-33e28560ac798067b6ddf8d3f8835bb6?source=copy_link

# 概要
オンボーディング画面の「学食メニュー」ページの表示/非表示を、`isFunchEnabled`フラグで制御するようにした。

# 変更内容
- `OnboardingPage.pages`を静的constリストから`isFunchEnabled`パラメータを受け取るメソッドに変更し、`false`の場合は学食メニューページを除外
- `OnboardingScreen`を`HookWidget`から`HookConsumerWidget`に変更し、`configProvider`経由で`isFunchEnabled`を取得
- `_buildBottomArea`のインジケータ数を動的なページ数から算出するように修正

# 確認事項
- [x] `isFunchEnabled = true` の場合、学食メニューページが表示される
- [x] `isFunchEnabled = false` の場合、学食メニューページが非表示になる
- [x] ページインジケータの数がページ数に連動している
- [x] 「次へ」ボタンと「はじめる」ボタンの切り替えが正しく動作する

# UI差分

https://gyazo.com/844274b7f5cec8368965512ebbacf304