### PR TITLE
ログアウト確認ダイアログの実装

### DIFF
--- a/Flutter/lib/feature/setting/settings.dart
+++ b/Flutter/lib/feature/setting/settings.dart
@@ -67,7 +67,7 @@ final class SettingsScreen extends ConsumerWidget {
                     onPressed: () {
                       Navigator.of(dialogContext).pop();
                     },
-                    child: const Text('いいえ'),
+                    child: const Text('キャンセル'),
                   ),
                 ),
                 const SizedBox(width: 12),
@@ -77,7 +77,7 @@ final class SettingsScreen extends ConsumerWidget {
                       Navigator.of(dialogContext).pop();
                       unawaited(ref.read(userProvider.notifier).signOut());
                     },
-                    child: const Text('はい'),
+                    child: const Text('ログアウト'),
                   ),
                 ),
               ],

--- a/Flutter/lib/feature/setting/settings.dart
+++ b/Flutter/lib/feature/setting/settings.dart
@@ -47,34 +47,34 @@ final class SettingsScreen extends ConsumerWidget {
     );
   }
 
-Future<void> _showLogoutConfirmDialog(
-  BuildContext context,
-  WidgetRef ref,
-) async {
-  await showDialog<void>(
-    context: context,
-    builder: (dialogContext) {
-      return AlertDialog(
-        title: const Text('ログアウトしますか？'),
-        actions: [
-          TextButton(
-            onPressed: () {
-              Navigator.of(dialogContext).pop();
-            },
-            child: const Text('いいえ'),
-          ),
-          TextButton(
-            onPressed: () {
-              Navigator.of(dialogContext).pop();
-              unawaited(ref.read(userProvider.notifier).signOut());
-            },
-            child: const Text('はい'),
-          ),
-        ],
-      );
-    },
-  );
-}
+  Future<void> _showLogoutConfirmDialog(
+    BuildContext context,
+    WidgetRef ref,
+  ) async {
+    await showDialog<void>(
+      context: context,
+      builder: (dialogContext) {
+        return AlertDialog(
+          title: const Text('ログアウトしますか？'),
+          actions: [
+            TextButton(
+              onPressed: () {
+                Navigator.of(dialogContext).pop();
+              },
+              child: const Text('いいえ'),
+            ),
+            TextButton(
+              onPressed: () {
+                Navigator.of(dialogContext).pop();
+                unawaited(ref.read(userProvider.notifier).signOut());
+              },
+              child: const Text('はい'),
+            ),
+          ],
+        );
+      },
+    );
+  }
 
   Future<bool> canOpenDebugScreen() async {
     if (kDebugMode) {
@@ -138,7 +138,9 @@ Future<void> _showLogoutConfirmDialog(
                         child: UserInfoTile(
                           user: value,
                           onTap: value.id.isNotEmpty
-                              ? () => ref.read(userProvider.notifier).signOut()
+                              ? () async {
+                                  await _showLogoutConfirmDialog(context, ref);
+                                }
                               : () async {
                                   await ref
                                       .read(userProvider.notifier)
@@ -161,8 +163,12 @@ Future<void> _showLogoutConfirmDialog(
                           child: UserInfoTile(
                             user: previousUser,
                             onTap: isAuthenticated
-                                ? () =>
-                                      ref.read(userProvider.notifier).signOut()
+                                ? () async {
+                                    await _showLogoutConfirmDialog(
+                                      context,
+                                      ref,
+                                    );
+                                  }
                                 : () async {
                                     await ref
                                         .read(userProvider.notifier)

--- a/Flutter/lib/feature/setting/settings.dart
+++ b/Flutter/lib/feature/setting/settings.dart
@@ -47,6 +47,35 @@ final class SettingsScreen extends ConsumerWidget {
     );
   }
 
+Future<void> _showLogoutConfirmDialog(
+  BuildContext context,
+  WidgetRef ref,
+) async {
+  await showDialog<void>(
+    context: context,
+    builder: (dialogContext) {
+      return AlertDialog(
+        title: const Text('ログアウトしますか？'),
+        actions: [
+          TextButton(
+            onPressed: () {
+              Navigator.of(dialogContext).pop();
+            },
+            child: const Text('いいえ'),
+          ),
+          TextButton(
+            onPressed: () {
+              Navigator.of(dialogContext).pop();
+              unawaited(ref.read(userProvider.notifier).signOut());
+            },
+            child: const Text('はい'),
+          ),
+        ],
+      );
+    },
+  );
+}
+
   Future<bool> canOpenDebugScreen() async {
     if (kDebugMode) {
       return true;

--- a/Flutter/lib/feature/setting/settings.dart
+++ b/Flutter/lib/feature/setting/settings.dart
@@ -49,7 +49,7 @@ final class SettingsScreen extends ConsumerWidget {
 
   Future<void> _showLogoutConfirmDialog(
     BuildContext context,
-    WidgetRef ref,
+    VoidCallback onLogout,
   ) async {
     await showDialog<void>(
       context: context,
@@ -75,7 +75,7 @@ final class SettingsScreen extends ConsumerWidget {
                   child: TextButton(
                     onPressed: () {
                       Navigator.of(dialogContext).pop();
-                      unawaited(ref.read(userProvider.notifier).signOut());
+                      onLogout();
                     },
                     child: const Text('ログアウト'),
                   ),
@@ -151,7 +151,12 @@ final class SettingsScreen extends ConsumerWidget {
                           user: value,
                           onTap: value.id.isNotEmpty
                               ? () async {
-                                  await _showLogoutConfirmDialog(context, ref);
+                                  await _showLogoutConfirmDialog(
+                                    context,
+                                    () => unawaited(
+                                      ref.read(userProvider.notifier).signOut(),
+                                    ),
+                                  );
                                 }
                               : () async {
                                   await ref
@@ -178,7 +183,11 @@ final class SettingsScreen extends ConsumerWidget {
                                 ? () async {
                                     await _showLogoutConfirmDialog(
                                       context,
-                                      ref,
+                                      () => unawaited(
+                                        ref
+                                            .read(userProvider.notifier)
+                                            .signOut(),
+                                      ),
                                     );
                                   }
                                 : () async {

--- a/Flutter/lib/feature/setting/settings.dart
+++ b/Flutter/lib/feature/setting/settings.dart
@@ -55,7 +55,11 @@ final class SettingsScreen extends ConsumerWidget {
       context: context,
       builder: (dialogContext) {
         return AlertDialog(
-          title: const Text('ログアウトしますか？'),
+          title: null,
+          content: Text(
+            'ログアウトしますか？',
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
           actions: [
             TextButton(
               onPressed: () {

--- a/Flutter/lib/feature/setting/settings.dart
+++ b/Flutter/lib/feature/setting/settings.dart
@@ -61,6 +61,7 @@ final class SettingsScreen extends ConsumerWidget {
           ),
           actions: [
             Row(
+              spacing: 12,
               children: [
                 Expanded(
                   child: TextButton(
@@ -70,7 +71,6 @@ final class SettingsScreen extends ConsumerWidget {
                     child: const Text('キャンセル'),
                   ),
                 ),
-                const SizedBox(width: 12),
                 Expanded(
                   child: TextButton(
                     onPressed: () {

--- a/Flutter/lib/feature/setting/settings.dart
+++ b/Flutter/lib/feature/setting/settings.dart
@@ -55,8 +55,7 @@ final class SettingsScreen extends ConsumerWidget {
       context: context,
       builder: (dialogContext) {
         return AlertDialog(
-          title: null,
-          content: Text(
+          title: Text(
             'ログアウトしますか？',
             style: Theme.of(context).textTheme.titleMedium,
           ),

--- a/Flutter/lib/feature/setting/settings.dart
+++ b/Flutter/lib/feature/setting/settings.dart
@@ -61,18 +61,27 @@ final class SettingsScreen extends ConsumerWidget {
             style: Theme.of(context).textTheme.titleMedium,
           ),
           actions: [
-            TextButton(
-              onPressed: () {
-                Navigator.of(dialogContext).pop();
-              },
-              child: const Text('いいえ'),
-            ),
-            TextButton(
-              onPressed: () {
-                Navigator.of(dialogContext).pop();
-                unawaited(ref.read(userProvider.notifier).signOut());
-              },
-              child: const Text('はい'),
+            Row(
+              children: [
+                Expanded(
+                  child: TextButton(
+                    onPressed: () {
+                      Navigator.of(dialogContext).pop();
+                    },
+                    child: const Text('いいえ'),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: TextButton(
+                    onPressed: () {
+                      Navigator.of(dialogContext).pop();
+                      unawaited(ref.read(userProvider.notifier).signOut());
+                    },
+                    child: const Text('はい'),
+                  ),
+                ),
+              ],
             ),
           ],
         );


### PR DESCRIPTION
案件: [ログイン・ログアウト改善: ログアウトしますか？アラートを実装](https://github.com/orgs/fun-dotto/projects/1/views/6?pane=issue&itemId=143319556&issue=fun-dotto%7Cdotto-app%7C391)
（Notionでタスクが見当たらなかったので、GitHubのIssueのリンクを貼りました）

- Closes #391 
- Closes #226 

<!--以下はある場合のみコメントアウトを外して記述-->
<!--タスク: [タスク名](Notion URL)-->

# やったこと

- [x] ログイン済みの状態で、設定画面のユーザー情報をタップしたとき、即ログアウトせず 確認のダイアログを表示
- [x] ダイアログ表示の後、「はい」を選択すると `UserNotifier.signOut()` を実行しログアウト処理が行われる
- [x] ダイアログ表示の後、「いいえ」を選択すると、ダイアログは閉じてログイン状態は維持されるようにした
- [x] ダイアログ表示の後、ダイアログの外側をタップすると、ダイアログは閉じてログイン状態は維持されるようにした
- [x] `user.when` の `data` と `error`の両方で、同じ確認フローを呼び出すようにした
- [x] 「ログアウトしますか？」の文言を `content` の `Text` に置き、`titleMedium` で表示サイズを調整した
- [x] 「はい」「いいえ」を `Row` + `Expanded` で並べ、ボタンを横いっぱい・同幅になるようにレイアウトした
- [x] ダイアログの「はい」「いいえ」という文言の代わりに「ログアウト」「キャンセル」という文言に変更した（レビュー後/画像差し替え済み）

# 確認したこと

<!--CIワークフローで確認できること以外で確認したことを記述-->
<!--ビルドできること、テストが通ることなどはCIで確認できるので不要-->

- [x] ログイン済みの状態で、ユーザー情報をタップするとログアウトの確認ダイアログが表示されること
- [x] ダイアログの表示の後、「いいえ」を選択または外側タップでダイアログが閉じ、ログアウトされずに設定画面に留まること
- [x] ダイアログ表示の後、「はい」を選択すると、ログアウトされ、未ログイン時の表示になること
- [x] 未ログイン時にユーザー情報をタップした場合は、従来どおりログインフローに進むこと


 # UI 差分

|           Before           |           After            |
| :------------------------: | :------------------------: |
| ダイアログなし | <img src="https://github.com/user-attachments/assets/da927b6f-e219-4f51-b4da-6d1c29b16dc0" width="200" /> | 


 # コメント

ダイアログのUIについて、意見をお聞きしたいです。
FigmaにあるUI案は手書きだったため、こんなイメージかなと思いながらとりあえず実装しました。
Figmaでは「ログアウトしますか」とありましたが「ログアウトしますか？」とハテナをつけた方が分かりやすいかなと思い、ハテナをつけて実装しました。
また、Figmaでは選択肢の左側に「はい」右側に「いいえ」とあったのですが、Netflixのログアウト画面などを見ると、左側に「いいえ」右側に「はい」とあったので、後者で実装しました。
この二つの実装の良し悪しも含め、ダイアログ全体として、これでいいか意見をお聞きしたいです。