### PR TITLE
現在地に基づいてバスの方向を自動判定する

### DIFF
--- a/Flutter/lib/feature/bus/bus_reducer.dart
+++ b/Flutter/lib/feature/bus/bus_reducer.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:dotto/domain/bus_stop.dart';
 import 'package:dotto/domain/user_preference_keys.dart';
 import 'package:dotto/feature/bus/bus_state.dart';
+import 'package:dotto/helper/location_helper.dart';
 import 'package:dotto/helper/user_preference_repository.dart';
 import 'package:dotto/repository/repository_provider.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -26,11 +27,14 @@ final class BusReducer extends _$BusReducer {
     });
 
     final busRepository = ref.read(busRepositoryProvider);
+    final nearUniFuture = LocationHelper.isNearUniversity();
+
     final allStops = await busRepository.getAllBusStops();
     final trips = await busRepository.getBusTrips(allStops);
 
     final myBusStop = await _loadMyBusStop(allStops);
     final now = DateTime.now();
+    final isNearUni = await nearUniFuture;
 
     _startPolling();
 
@@ -40,6 +44,7 @@ final class BusReducer extends _$BusReducer {
       myBusStop: myBusStop,
       isWeekday: now.weekday <= DateTime.friday,
       currentTime: now,
+      isTo: !isNearUni,
     );
   }
 

--- a/Flutter/lib/helper/location_helper.dart
+++ b/Flutter/lib/helper/location_helper.dart
@@ -1,14 +1,15 @@
 import 'package:geolocator/geolocator.dart';
 
 abstract class LocationHelper {
-  static const double _universityLat = 41.8419;
-  static const double _universityLng = 140.7667;
-  static const double _nearThresholdMeters = 500;
+  static const double _universityLat = 41.841889;
+  static const double _universityLng = 140.766962;
+  static const double _nearThresholdMeters = 250;
 
   static Future<bool> isNearUniversity() async {
     try {
-      final position =
-          await determinePosition().timeout(const Duration(seconds: 5));
+      final position = await determinePosition().timeout(
+        const Duration(seconds: 5),
+      );
       if (position == null) return false;
       final distance = Geolocator.distanceBetween(
         position.latitude,

--- a/Flutter/lib/helper/location_helper.dart
+++ b/Flutter/lib/helper/location_helper.dart
@@ -1,6 +1,27 @@
 import 'package:geolocator/geolocator.dart';
 
 abstract class LocationHelper {
+  static const double _universityLat = 41.8419;
+  static const double _universityLng = 140.7667;
+  static const double _nearThresholdMeters = 500;
+
+  static Future<bool> isNearUniversity() async {
+    try {
+      final position =
+          await determinePosition().timeout(const Duration(seconds: 5));
+      if (position == null) return false;
+      final distance = Geolocator.distanceBetween(
+        position.latitude,
+        position.longitude,
+        _universityLat,
+        _universityLng,
+      );
+      return distance <= _nearThresholdMeters;
+    } on Exception catch (_) {
+      return false;
+    }
+  }
+
   static Future<bool> requestLocationPermission() async {
     if (!await Geolocator.isLocationServiceEnabled()) {
       return false;


### PR DESCRIPTION
案件: [バス: 現在地に基づいた始点が適用されない問題を修正](https://www.notion.so/fun-dotto/33e28560ac79801fa2d4e805cd69c5bd?source=copy_link)

## 概要
バス画面を開いたときに現在地を取得し、未来大キャンパスから500m以内にいる場合はバスの方向を「未来大→バス停」に自動設定するようにした。

## 背景
バス画面の方向（`isTo`）が常にデフォルト値 `true`（バス停→未来大）で表示されており、現在地に応じた自動切替が機能していなかった。

## 変更内容
- `LocationHelper` に `isNearUniversity()` メソッドを追加（未来大座標との距離を計算、5秒タイムアウト付き）
- `BusReducer.build()` でバスデータ取得と並行して位置情報を取得し、`isTo` の初期値を設定
- 位置情報の取得に失敗した場合は従来通り `isTo = true` にフォールバック
- 手動の方向切替ボタンは従来通り動作する

## 確認事項
- [x] 未来大付近で初期方向が「未来大→バス停」になること
- [x] 未来大から離れた場所で初期方向が「バス停→未来大」になること
- [x] 手動の方向切替ボタンが引き続き動作すること
- [x] 位置情報の権限を拒否した場合にデフォルト動作になること