### PR TITLE
バス画面で祝日は休日時刻表を自動選択する

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,3 +35,5 @@
   - MVVM + UseCase + Repository パターンが使われていることがあるが、現在は非推奨。
   - RepositoryはRiverpodに依存しないこと。
   - Repositoryは互いに独立していること。
+- 日付整形
+  - `DateFormat` は各所で直接使わず、`lib/helper/date_formatter.dart` の `DateFormatter` クラスにメソッドとして定義して利用すること。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,5 +35,6 @@
   - MVVM + UseCase + Repository パターンが使われていることがあるが、現在は非推奨。
   - RepositoryはRiverpodに依存しないこと。
   - Repositoryは互いに独立していること。
+  - Repository が画面層に例外を伝播させる場合は、`DomainError` に変換して throw すること。生の `DioException` / `FirebaseException` / `Exception` をそのまま投げない。
 - 日付整形
   - `DateFormat` は各所で直接使わず、`lib/helper/date_formatter.dart` の `DateFormatter` クラスにメソッドとして定義して利用すること。

--- a/Flutter/lib/domain/user_preference_keys.dart
+++ b/Flutter/lib/domain/user_preference_keys.dart
@@ -10,9 +10,7 @@ enum UserPreferenceKeys {
   isAppTutorialComplete(key: 'isAppTutorialCompleted', type: bool),
   myBusStop(key: 'myBusStop', type: int),
   timetablePeriodStyle(key: 'timetablePeriodStyle', type: String),
-  isFunchEnabledOverride(key: 'isFunchEnabledOverride', type: bool),
-  holidayCacheJson(key: 'holidayCacheJson', type: String),
-  holidayCacheFetchedAt(key: 'holidayCacheFetchedAt', type: int);
+  isFunchEnabledOverride(key: 'isFunchEnabledOverride', type: bool);
 
   const UserPreferenceKeys({required this.key, required this.type});
 

--- a/Flutter/lib/domain/user_preference_keys.dart
+++ b/Flutter/lib/domain/user_preference_keys.dart
@@ -10,7 +10,9 @@ enum UserPreferenceKeys {
   isAppTutorialComplete(key: 'isAppTutorialCompleted', type: bool),
   myBusStop(key: 'myBusStop', type: int),
   timetablePeriodStyle(key: 'timetablePeriodStyle', type: String),
-  isFunchEnabledOverride(key: 'isFunchEnabledOverride', type: bool);
+  isFunchEnabledOverride(key: 'isFunchEnabledOverride', type: bool),
+  holidayCacheJson(key: 'holidayCacheJson', type: String),
+  holidayCacheFetchedAt(key: 'holidayCacheFetchedAt', type: int);
 
   const UserPreferenceKeys({required this.key, required this.type});
 

--- a/Flutter/lib/feature/bus/bus_reducer.dart
+++ b/Flutter/lib/feature/bus/bus_reducer.dart
@@ -40,7 +40,12 @@ final class BusReducer extends _$BusReducer {
     final myBusStop = await _loadMyBusStop(allStops);
     final now = DateTime.now();
     final isNearUni = await nearUniFuture;
-    final holidayDates = await holidayDatesFuture;
+    Set<String> holidayDates;
+    try {
+      holidayDates = await holidayDatesFuture;
+    } on Object {
+      holidayDates = const <String>{};
+    }
     final isHolidayToday = holidayDates.contains(DateFormatter.date(now));
 
     _startPolling();

--- a/Flutter/lib/feature/bus/bus_reducer.dart
+++ b/Flutter/lib/feature/bus/bus_reducer.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:dotto/domain/bus_stop.dart';
 import 'package:dotto/domain/user_preference_keys.dart';
 import 'package:dotto/feature/bus/bus_state.dart';
+import 'package:dotto/helper/date_formatter.dart';
 import 'package:dotto/helper/location_helper.dart';
 import 'package:dotto/helper/user_preference_repository.dart';
 import 'package:dotto/repository/repository_provider.dart';
@@ -40,7 +41,7 @@ final class BusReducer extends _$BusReducer {
     final now = DateTime.now();
     final isNearUni = await nearUniFuture;
     final holidayDates = await holidayDatesFuture;
-    final isHolidayToday = holidayDates.contains(_formatYmd(now));
+    final isHolidayToday = holidayDates.contains(DateFormatter.date(now));
 
     _startPolling();
 
@@ -52,13 +53,6 @@ final class BusReducer extends _$BusReducer {
       currentTime: now,
       isTo: !isNearUni,
     );
-  }
-
-  String _formatYmd(DateTime date) {
-    final y = date.year.toString().padLeft(4, '0');
-    final m = date.month.toString().padLeft(2, '0');
-    final d = date.day.toString().padLeft(2, '0');
-    return '$y-$m-$d';
   }
 
   Future<BusStop> _loadMyBusStop(List<BusStop> allStops) async {

--- a/Flutter/lib/feature/bus/bus_reducer.dart
+++ b/Flutter/lib/feature/bus/bus_reducer.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:dotto/domain/bus_stop.dart';
+import 'package:dotto/domain/domain_error.dart';
 import 'package:dotto/domain/user_preference_keys.dart';
 import 'package:dotto/feature/bus/bus_state.dart';
 import 'package:dotto/helper/date_formatter.dart';
@@ -43,7 +44,7 @@ final class BusReducer extends _$BusReducer {
     Set<String> holidayDates;
     try {
       holidayDates = await holidayDatesFuture;
-    } on Object {
+    } on DomainError {
       holidayDates = const <String>{};
     }
     final isHolidayToday = holidayDates.contains(DateFormatter.date(now));

--- a/Flutter/lib/feature/bus/bus_reducer.dart
+++ b/Flutter/lib/feature/bus/bus_reducer.dart
@@ -29,7 +29,9 @@ final class BusReducer extends _$BusReducer {
     });
 
     final busRepository = ref.read(busRepositoryProvider);
+    final holidayRepository = ref.read(holidayRepositoryProvider);
     final nearUniFuture = LocationHelper.isNearUniversity();
+    final holidayDatesFuture = holidayRepository.getHolidayDates();
 
     final allStops = await busRepository.getAllBusStops();
     final trips = await busRepository.getBusTrips(allStops);
@@ -37,6 +39,8 @@ final class BusReducer extends _$BusReducer {
     final myBusStop = await _loadMyBusStop(allStops);
     final now = DateTime.now();
     final isNearUni = await nearUniFuture;
+    final holidayDates = await holidayDatesFuture;
+    final isHolidayToday = holidayDates.contains(_formatYmd(now));
 
     _startPolling();
 
@@ -44,10 +48,17 @@ final class BusReducer extends _$BusReducer {
       trips: trips,
       allStops: allStops,
       myBusStop: myBusStop,
-      isWeekday: now.weekday <= DateTime.friday,
+      isWeekday: now.weekday <= DateTime.friday && !isHolidayToday,
       currentTime: now,
       isTo: !isNearUni,
     );
+  }
+
+  String _formatYmd(DateTime date) {
+    final y = date.year.toString().padLeft(4, '0');
+    final m = date.month.toString().padLeft(2, '0');
+    final d = date.day.toString().padLeft(2, '0');
+    return '$y-$m-$d';
   }
 
   Future<BusStop> _loadMyBusStop(List<BusStop> allStops) async {

--- a/Flutter/lib/repository/holiday_repository.dart
+++ b/Flutter/lib/repository/holiday_repository.dart
@@ -1,0 +1,74 @@
+import 'dart:convert';
+
+import 'package:dotto/domain/user_preference_keys.dart';
+import 'package:dotto/helper/user_preference_repository.dart';
+import 'package:http/http.dart' as http;
+
+abstract class HolidayRepository {
+  Future<Set<String>> getHolidayDates();
+}
+
+final class HolidayRepositoryImpl implements HolidayRepository {
+  static final Uri _endpoint = Uri.parse(
+    'https://holidays-jp.github.io/api/v1/date.json',
+  );
+  static const Duration _cacheDuration = Duration(days: 1);
+
+  @override
+  Future<Set<String>> getHolidayDates() async {
+    final cachedJson = await UserPreferenceRepository.getString(
+      UserPreferenceKeys.holidayCacheJson,
+    );
+    final fetchedAt = await UserPreferenceRepository.getInt(
+      UserPreferenceKeys.holidayCacheFetchedAt,
+    );
+
+    final now = DateTime.now();
+    final isFresh = cachedJson != null &&
+        fetchedAt != null &&
+        now.millisecondsSinceEpoch - fetchedAt < _cacheDuration.inMilliseconds;
+
+    if (isFresh) {
+      final parsed = _tryParse(cachedJson);
+      if (parsed != null) return parsed;
+    }
+
+    try {
+      final response = await http.get(_endpoint);
+      if (response.statusCode == 200) {
+        final parsed = _tryParse(response.body);
+        if (parsed != null) {
+          await UserPreferenceRepository.setString(
+            UserPreferenceKeys.holidayCacheJson,
+            response.body,
+          );
+          await UserPreferenceRepository.setInt(
+            UserPreferenceKeys.holidayCacheFetchedAt,
+            now.millisecondsSinceEpoch,
+          );
+          return parsed;
+        }
+      }
+    } on Exception {
+      // ignore and fall through to stale cache / empty
+    }
+
+    if (cachedJson != null) {
+      final parsed = _tryParse(cachedJson);
+      if (parsed != null) return parsed;
+    }
+    return <String>{};
+  }
+
+  Set<String>? _tryParse(String body) {
+    try {
+      final decoded = jsonDecode(body);
+      if (decoded is Map) {
+        return decoded.keys.map((e) => e.toString()).toSet();
+      }
+    } on FormatException {
+      return null;
+    }
+    return null;
+  }
+}

--- a/Flutter/lib/repository/holiday_repository.dart
+++ b/Flutter/lib/repository/holiday_repository.dart
@@ -21,8 +21,12 @@ final class HolidayRepositoryImpl implements HolidayRepository {
     final filePath = await FileHelper.getApplicationFilePath(_cacheFilePath);
     final file = File(filePath);
 
-    if (file.existsSync()) {
-      final age = DateTime.now().difference(file.lastModifiedSync());
+    // UI 起動経路で呼ばれるため、同期 I/O を避けて非同期 API を使う。
+    // ignore: avoid_slow_async_io
+    if (await file.exists()) {
+      // UI 起動経路で呼ばれるため、同期 I/O を避けて非同期 API を使う。
+      // ignore: avoid_slow_async_io
+      final age = DateTime.now().difference(await file.lastModified());
       if (age < _cacheDuration) {
         final parsed = _tryParse(await file.readAsString());
         if (parsed != null) return parsed;
@@ -42,7 +46,9 @@ final class HolidayRepositoryImpl implements HolidayRepository {
       // ignore and fall through to stale cache / empty
     }
 
-    if (file.existsSync()) {
+    // UI 起動経路で呼ばれるため、同期 I/O を避けて非同期 API を使う。
+    // ignore: avoid_slow_async_io
+    if (await file.exists()) {
       final parsed = _tryParse(await file.readAsString());
       if (parsed != null) return parsed;
     }

--- a/Flutter/lib/repository/holiday_repository.dart
+++ b/Flutter/lib/repository/holiday_repository.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
+import 'dart:io';
 
-import 'package:dotto/domain/user_preference_keys.dart';
-import 'package:dotto/helper/user_preference_repository.dart';
+import 'package:dotto/helper/file_helper.dart';
 import 'package:http/http.dart' as http;
 
 abstract class HolidayRepository {
@@ -12,25 +12,20 @@ final class HolidayRepositoryImpl implements HolidayRepository {
   static final Uri _endpoint = Uri.parse(
     'https://holidays-jp.github.io/api/v1/date.json',
   );
+  static const String _cacheFilePath = 'holiday/date.json';
   static const Duration _cacheDuration = Duration(days: 1);
 
   @override
   Future<Set<String>> getHolidayDates() async {
-    final cachedJson = await UserPreferenceRepository.getString(
-      UserPreferenceKeys.holidayCacheJson,
-    );
-    final fetchedAt = await UserPreferenceRepository.getInt(
-      UserPreferenceKeys.holidayCacheFetchedAt,
-    );
+    final filePath = await FileHelper.getApplicationFilePath(_cacheFilePath);
+    final file = File(filePath);
 
-    final now = DateTime.now();
-    final isFresh = cachedJson != null &&
-        fetchedAt != null &&
-        now.millisecondsSinceEpoch - fetchedAt < _cacheDuration.inMilliseconds;
-
-    if (isFresh) {
-      final parsed = _tryParse(cachedJson);
-      if (parsed != null) return parsed;
+    if (file.existsSync()) {
+      final age = DateTime.now().difference(file.lastModifiedSync());
+      if (age < _cacheDuration) {
+        final parsed = _tryParse(await file.readAsString());
+        if (parsed != null) return parsed;
+      }
     }
 
     try {
@@ -38,14 +33,7 @@ final class HolidayRepositoryImpl implements HolidayRepository {
       if (response.statusCode == 200) {
         final parsed = _tryParse(response.body);
         if (parsed != null) {
-          await UserPreferenceRepository.setString(
-            UserPreferenceKeys.holidayCacheJson,
-            response.body,
-          );
-          await UserPreferenceRepository.setInt(
-            UserPreferenceKeys.holidayCacheFetchedAt,
-            now.millisecondsSinceEpoch,
-          );
+          await file.writeAsString(response.body, flush: true);
           return parsed;
         }
       }
@@ -53,8 +41,8 @@ final class HolidayRepositoryImpl implements HolidayRepository {
       // ignore and fall through to stale cache / empty
     }
 
-    if (cachedJson != null) {
-      final parsed = _tryParse(cachedJson);
+    if (file.existsSync()) {
+      final parsed = _tryParse(await file.readAsString());
       if (parsed != null) return parsed;
     }
     return <String>{};

--- a/Flutter/lib/repository/holiday_repository.dart
+++ b/Flutter/lib/repository/holiday_repository.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:dotto/domain/domain_error.dart';
 import 'package:dotto/helper/file_helper.dart';
 import 'package:http/http.dart' as http;
 
@@ -35,24 +36,39 @@ final class HolidayRepositoryImpl implements HolidayRepository {
 
     try {
       final response = await http.get(_endpoint).timeout(_requestTimeout);
-      if (response.statusCode == 200) {
-        final parsed = _tryParse(response.body);
-        if (parsed != null) {
-          await file.writeAsString(response.body, flush: true);
-          return parsed;
-        }
+      if (response.statusCode != 200) {
+        throw DomainError(
+          type: DomainErrorType.server,
+          message: 'Failed to fetch holidays: status ${response.statusCode}',
+        );
       }
-    } on Exception {
-      // ignore and fall through to stale cache / empty
+      final parsed = _tryParse(response.body);
+      if (parsed == null) {
+        throw const DomainError(
+          type: DomainErrorType.invalidResponse,
+          message: 'Failed to parse holidays JSON',
+        );
+      }
+      await file.writeAsString(response.body, flush: true);
+      return parsed;
+    } on DomainError {
+      final stale = await _readStaleCache(file);
+      if (stale != null) return stale;
+      rethrow;
+    } on Exception catch (e, st) {
+      final stale = await _readStaleCache(file);
+      if (stale != null) return stale;
+      throw DomainError.fromException(e: e, stackTrace: st);
     }
+  }
 
+  Future<Set<String>?> _readStaleCache(File file) async {
     // UI 起動経路で呼ばれるため、同期 I/O を避けて非同期 API を使う。
     // ignore: avoid_slow_async_io
     if (await file.exists()) {
-      final parsed = _tryParse(await file.readAsString());
-      if (parsed != null) return parsed;
+      return _tryParse(await file.readAsString());
     }
-    return <String>{};
+    return null;
   }
 
   Set<String>? _tryParse(String body) {

--- a/Flutter/lib/repository/holiday_repository.dart
+++ b/Flutter/lib/repository/holiday_repository.dart
@@ -14,6 +14,7 @@ final class HolidayRepositoryImpl implements HolidayRepository {
   );
   static const String _cacheFilePath = 'holiday/date.json';
   static const Duration _cacheDuration = Duration(days: 1);
+  static const Duration _requestTimeout = Duration(seconds: 10);
 
   @override
   Future<Set<String>> getHolidayDates() async {
@@ -29,7 +30,7 @@ final class HolidayRepositoryImpl implements HolidayRepository {
     }
 
     try {
-      final response = await http.get(_endpoint);
+      final response = await http.get(_endpoint).timeout(_requestTimeout);
       if (response.statusCode == 200) {
         final parsed = _tryParse(response.body);
         if (parsed != null) {

--- a/Flutter/lib/repository/repository_provider.dart
+++ b/Flutter/lib/repository/repository_provider.dart
@@ -3,6 +3,7 @@ import 'package:dotto/helper/firebase_realtime_database_repository.dart';
 import 'package:dotto/repository/bus_repository.dart';
 import 'package:dotto/repository/course_registration_repository.dart';
 import 'package:dotto/repository/fcm_token_repository.dart';
+import 'package:dotto/repository/holiday_repository.dart';
 import 'package:dotto/repository/personal_calendar_repository.dart';
 import 'package:dotto/repository/room_repository.dart';
 import 'package:dotto/repository/timetable_repository.dart';
@@ -10,6 +11,10 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 final busRepositoryProvider = Provider<BusRepository>(
   (_) => BusRepositoryImpl(FirebaseRealtimeDatabaseRepository()),
+);
+
+final holidayRepositoryProvider = Provider<HolidayRepository>(
+  (_) => HolidayRepositoryImpl(),
 );
 
 final fcmTokenRepositoryProvider = Provider<FCMTokenRepository>(


### PR DESCRIPTION
案件: 機能改善（バス画面の祝日対応）

# やったこと

- [x] `holidays-jp.github.io/api/v1/date.json` から日本の祝日一覧を取得する `HolidayRepository` を追加
- [x] 取得した JSON をテンポラリディレクトリ (`holiday/date.json`) にファイルとしてキャッシュし、最終更新時刻から 24 時間以内なら再利用
- [x] HTTP 取得にタイムアウト (10 秒) を設定し、失敗時は古いキャッシュにフォールバック、キャッシュも無ければ空集合
- [x] `BusReducer.build()` で祝日集合を並行取得し、今日が祝日なら `isWeekday` を `false` にして休日時刻表を初期選択
- [x] 祝日取得で例外が漏れても画面起動が阻害されないよう try/catch で吸収
- [x] `_formatYmd` のような自前整形は使わず `DateFormatter.date()` を利用し、AGENTS.md にその方針を明記

# 確認したこと

- [x] 平日にあたる祝日（例: 月曜の祝日）で起動すると休日時刻表が初期選択される
- [x] 通常の平日では平日時刻表が初期選択される
- [x] オフライン起動でもクラッシュせず、従来どおりの曜日ロジックで起動する
- [x] 2 回目起動時に祝日 API が叩かれずキャッシュが使われる