### PR TITLE
Renovate PRでpubspec.lockを自動更新するワークフローを追加

### DIFF
--- a/.github/workflows/update-pubspec-lock.yml
+++ b/.github/workflows/update-pubspec-lock.yml
@@ -1,0 +1,43 @@
+name: Update pubspec.lock
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  update-lock:
+    name: Update pubspec.lock
+    if: github.event.pull_request.user.login == 'renovate[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        with:
+          github_token: ${{ github.token }}
+          cache: true
+          working_directory: .
+      - name: Update pubspec.lock
+        run: flutter pub get
+      - name: Commit pubspec.lock
+        run: |
+          if git diff --quiet -- pubspec.lock; then
+            echo "pubspec.lock に差分はありません。"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add pubspec.lock
+          git commit -m "pubspec.lockを更新"
+          git push


### PR DESCRIPTION
# 変更点

<!--
変更内容を分かりやすく記載する
-->

- Renovate が作成した PR で `pubspec.lock` を自動更新する GitHub Actions ワークフロー `update-pubspec-lock.yml` を追加
  - 本リポジトリは pub workspace 構成のため `pubspec.lock` がルートに1つしかなく、Renovate の pub マネージャ（manifest と同階層の lock を探す実装）では lock が更新されない問題への対処
  - `renovate[bot]` が作者の PR の opened / synchronize 時のみ実行
  - `flutter pub get` を実行し、`pubspec.lock` に差分がある場合のみ PR ブランチへコミット & push
  - 組織ポリシーに従い、使用アクションは SHA 固定＋タグをコメント併記

## 注意点

- `GITHUB_TOKEN` による push は他のワークフロー（CI 等）を再トリガーしないため、lock 更新コミット後に CI を自動実行させたい場合は PAT または GitHub App トークンへの切り替えが必要

🤖 Generated with [Claude Code](https://claude.com/claude-code)