### PR TITLE
Feature flagを一元管理できる仕組みを導入

### DIFF
--- a/apps/dotto/lib/controller/config_controller.dart
+++ b/apps/dotto/lib/controller/config_controller.dart
@@ -1,35 +1,16 @@
-import 'dart:async';
-
 import 'package:dotto/domain/breaking_announcement.dart';
 import 'package:dotto/domain/config.dart';
 import 'package:dotto/domain/remote_config_keys.dart';
-import 'package:dotto/domain/user_preference_keys.dart';
 import 'package:dotto/helper/remote_config_helper.dart';
-import 'package:dotto/helper/user_preference_repository.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'config_controller.g.dart';
 
 @Riverpod(keepAlive: true)
 final class ConfigNotifier extends _$ConfigNotifier {
-  bool? _isFunchEnabledOverride;
-  bool _didStartLoadingOverride = false;
-
-  bool? get isFunchEnabledOverride => _isFunchEnabledOverride;
-
   @override
   Config build() {
-    if (!_didStartLoadingOverride) {
-      _didStartLoadingOverride = true;
-      unawaited(loadOverrides());
-    }
-
     final remoteConfigRepository = ref.read(remoteConfigHelperProvider);
-    final remoteConfigIsFunchEnabled = remoteConfigRepository.getBool(
-      RemoteConfigKeys.isFunchEnabled,
-    );
-    final isFunchEnabled =
-        _isFunchEnabledOverride ?? remoteConfigIsFunchEnabled;
     final validAppVersion = remoteConfigRepository.getString(
       RemoteConfigKeys.validAppVersion,
     );
@@ -91,7 +72,6 @@ final class ConfigNotifier extends _$ConfigNotifier {
     }
 
     return Config(
-      isFunchEnabled: isFunchEnabled,
       validAppVersion: validAppVersion,
       latestAppVersion: latestAppVersion,
       isUnderMaintenance: isUnderMaintenance,
@@ -110,41 +90,6 @@ final class ConfigNotifier extends _$ConfigNotifier {
 
   void refresh() {
     state = build();
-  }
-
-  Future<void> loadOverrides() async {
-    await _loadIsFunchEnabledOverride(refreshAfterLoad: false);
-    refresh();
-  }
-
-  Future<void> loadIsFunchEnabledOverride() async {
-    await _loadIsFunchEnabledOverride(refreshAfterLoad: true);
-  }
-
-  Future<void> setIsFunchEnabledOverride({required bool? value}) async {
-    _isFunchEnabledOverride = value;
-    if (value == null) {
-      await UserPreferenceRepository.remove(
-        UserPreferenceKeys.isFunchEnabledOverride,
-      );
-    } else {
-      await UserPreferenceRepository.setBool(
-        UserPreferenceKeys.isFunchEnabledOverride,
-        value: value,
-      );
-    }
-    refresh();
-  }
-
-  Future<void> _loadIsFunchEnabledOverride({
-    required bool refreshAfterLoad,
-  }) async {
-    _isFunchEnabledOverride = await UserPreferenceRepository.getBool(
-      UserPreferenceKeys.isFunchEnabledOverride,
-    );
-    if (refreshAfterLoad) {
-      refresh();
-    }
   }
 
   String? _asStringOrNull(Object? value) {

--- a/apps/dotto/lib/controller/feature_flag_controller.dart
+++ b/apps/dotto/lib/controller/feature_flag_controller.dart
@@ -9,8 +9,8 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 part 'feature_flag_controller.g.dart';
 
 /// Debug用overrideの一覧 (フラグのkey -> override値) を保持するNotifier。
-@Riverpod(keepAlive: true, name: 'featureFlagNotifierProvider')
-final class FeatureFlagNotifier extends _$FeatureFlagNotifier {
+@Riverpod(keepAlive: true)
+final class FlagOverridesNotifier extends _$FlagOverridesNotifier {
   @override
   Map<String, Object?> build() {
     unawaited(loadOverrides());
@@ -34,7 +34,7 @@ final class FeatureFlagNotifier extends _$FeatureFlagNotifier {
 /// FeatureFlagの実効値 (Debug用override > Remote Config) を返す。
 @Riverpod(keepAlive: true)
 T featureFlag<T>(Ref ref, Flag<T> flag) {
-  final override = ref.watch(featureFlagNotifierProvider)[flag.key];
+  final override = ref.watch(flagOverridesProvider)[flag.key];
   if (override is T) return override;
   return ref.watch(featureFlagRepositoryProvider).get(flag);
 }

--- a/apps/dotto/lib/controller/feature_flag_controller.dart
+++ b/apps/dotto/lib/controller/feature_flag_controller.dart
@@ -1,0 +1,42 @@
+import 'dart:async';
+
+import 'package:dotto/foundation/flag.dart';
+import 'package:dotto/foundation/flags.dart';
+import 'package:dotto/repository/feature_flag_repository.dart';
+import 'package:dotto/repository/flag_override_store.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'feature_flag_controller.g.dart';
+
+/// Debug用overrideの一覧 (フラグのkey -> override値) を保持するNotifier。
+@Riverpod(keepAlive: true)
+final class FeatureFlagNotifier extends _$FeatureFlagNotifier {
+  @override
+  Map<String, Object?> build() {
+    unawaited(loadOverrides());
+    return const {};
+  }
+
+  Future<void> setOverride(Flag<bool> flag, {required bool? value}) async {
+    await ref.read(flagOverrideStoreProvider).set(flag, value: value);
+    if (value == null) {
+      state = {...state}..remove(flag.key);
+    } else {
+      state = {...state, flag.key: value};
+    }
+  }
+
+  Future<void> loadOverrides() async {
+    state = await ref.read(flagOverrideStoreProvider).load(Flags.all);
+  }
+}
+
+/// FeatureFlagの実効値 (Debug用override > Remote Config) を返す。
+@Riverpod(keepAlive: true)
+T featureFlag<T>(Ref ref, Flag<T> flag) {
+  final override = ref.watch(
+    featureFlagNotifierProvider.select((overrides) => overrides[flag.key]),
+  );
+  if (override is T) return override;
+  return ref.watch(featureFlagRepositoryProvider).get(flag);
+}

--- a/apps/dotto/lib/controller/feature_flag_controller.dart
+++ b/apps/dotto/lib/controller/feature_flag_controller.dart
@@ -9,7 +9,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 part 'feature_flag_controller.g.dart';
 
 /// Debug用overrideの一覧 (フラグのkey -> override値) を保持するNotifier。
-@Riverpod(keepAlive: true)
+@Riverpod(keepAlive: true, name: 'featureFlagNotifierProvider')
 final class FeatureFlagNotifier extends _$FeatureFlagNotifier {
   @override
   Map<String, Object?> build() {
@@ -34,9 +34,7 @@ final class FeatureFlagNotifier extends _$FeatureFlagNotifier {
 /// FeatureFlagの実効値 (Debug用override > Remote Config) を返す。
 @Riverpod(keepAlive: true)
 T featureFlag<T>(Ref ref, Flag<T> flag) {
-  final override = ref.watch(
-    featureFlagNotifierProvider.select((overrides) => overrides[flag.key]),
-  );
+  final override = ref.watch(featureFlagNotifierProvider)[flag.key];
   if (override is T) return override;
   return ref.watch(featureFlagRepositoryProvider).get(flag);
 }

--- a/apps/dotto/lib/domain/config.dart
+++ b/apps/dotto/lib/domain/config.dart
@@ -6,7 +6,6 @@ part 'config.freezed.dart';
 @freezed
 abstract class Config with _$Config {
   const factory Config({
-    required bool isFunchEnabled,
     required String validAppVersion,
     required String latestAppVersion,
     required bool isUnderMaintenance,

--- a/apps/dotto/lib/domain/remote_config_keys.dart
+++ b/apps/dotto/lib/domain/remote_config_keys.dart
@@ -1,7 +1,4 @@
 final class RemoteConfigKeys {
-  /// Funch feature flag
-  static const String isFunchEnabled = 'is_funch_enabled';
-
   /// サポート対象の最小バージョン
   ///
   /// 現在のアプリバージョンがこの値より小さい場合: 強制アップデート対象

--- a/apps/dotto/lib/domain/user_preference_keys.dart
+++ b/apps/dotto/lib/domain/user_preference_keys.dart
@@ -10,7 +10,6 @@ enum UserPreferenceKeys {
   isAppTutorialComplete(key: 'isAppTutorialCompleted', type: bool),
   myBusStop(key: 'myBusStop', type: int),
   timetablePeriodStyle(key: 'timetablePeriodStyle', type: String),
-  isFunchEnabledOverride(key: 'isFunchEnabledOverride', type: bool),
   notificationPromptLastShownAt(
     key: 'notificationPromptLastShownAt',
     type: int,

--- a/apps/dotto/lib/feature/course/course_screen.dart
+++ b/apps/dotto/lib/feature/course/course_screen.dart
@@ -23,7 +23,7 @@ final class CourseScreen extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final config = ref.watch(configProvider);
-    final flag = useFlag(ref);
+    final isFunchEnabled = useFlag(Flags.funch);
     final isAuthenticated = ref.watch(isAuthenticatedProvider);
     final state = isAuthenticated
         ? ref.watch(courseReducerProvider)
@@ -31,19 +31,13 @@ final class CourseScreen extends HookConsumerWidget {
     final selectedDate = useState<DateTime?>(null);
 
     final quickFeatures = [
-      ...flag.switchOn<List<QuickButton>>(
-        Flags.funch,
-        onTrue: () => [
-          QuickButton(
-            label: '科目検索',
-            iconUrl: null,
-            fallbackIcon: Icons.search,
-            onPressed: () =>
-                const CourseSubjectsRouteData().push<void>(context),
-          ),
-        ],
-        onFalse: () => const [],
-      ),
+      if (isFunchEnabled)
+        QuickButton(
+          label: '科目検索',
+          iconUrl: null,
+          fallbackIcon: Icons.search,
+          onPressed: () => const CourseSubjectsRouteData().push<void>(context),
+        ),
       if (isAuthenticated)
         QuickButton(
           label: '休講・補講',

--- a/apps/dotto/lib/feature/course/course_screen.dart
+++ b/apps/dotto/lib/feature/course/course_screen.dart
@@ -4,9 +4,9 @@ import 'package:dotto/controller/config_controller.dart';
 import 'package:dotto/controller/user_controller.dart';
 import 'package:dotto/feature/course/course_reducer.dart';
 import 'package:dotto/feature/course/course_state.dart';
-import 'package:dotto/domain/remote_config_keys.dart';
 import 'package:dotto/feature/course/personal_timetable_calendar_view.dart';
 import 'package:dotto/feature/course/quick_button.dart';
+import 'package:dotto/foundation/flags.dart';
 import 'package:dotto/foundation/use_flag.dart';
 import 'package:dotto/helper/url_launcher_helper.dart';
 import 'package:dotto/router/routes/app_routes.dart';
@@ -32,7 +32,7 @@ final class CourseScreen extends HookConsumerWidget {
 
     final quickFeatures = [
       ...flag.switchOn<List<QuickButton>>(
-        RemoteConfigKeys.isFunchEnabled,
+        Flags.funch,
         onTrue: () => [
           QuickButton(
             label: '科目検索',

--- a/apps/dotto/lib/feature/course/course_screen.dart
+++ b/apps/dotto/lib/feature/course/course_screen.dart
@@ -4,8 +4,10 @@ import 'package:dotto/controller/config_controller.dart';
 import 'package:dotto/controller/user_controller.dart';
 import 'package:dotto/feature/course/course_reducer.dart';
 import 'package:dotto/feature/course/course_state.dart';
+import 'package:dotto/domain/remote_config_keys.dart';
 import 'package:dotto/feature/course/personal_timetable_calendar_view.dart';
 import 'package:dotto/feature/course/quick_button.dart';
+import 'package:dotto/foundation/use_flag.dart';
 import 'package:dotto/helper/url_launcher_helper.dart';
 import 'package:dotto/router/routes/app_routes.dart';
 import 'package:dotto_design_system/component/button.dart';
@@ -21,6 +23,7 @@ final class CourseScreen extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final config = ref.watch(configProvider);
+    final flag = useFlag(ref);
     final isAuthenticated = ref.watch(isAuthenticatedProvider);
     final state = isAuthenticated
         ? ref.watch(courseReducerProvider)
@@ -28,13 +31,19 @@ final class CourseScreen extends HookConsumerWidget {
     final selectedDate = useState<DateTime?>(null);
 
     final quickFeatures = [
-      if (config.isFunchEnabled)
-        QuickButton(
-          label: '科目検索',
-          iconUrl: null,
-          fallbackIcon: Icons.search,
-          onPressed: () => const CourseSubjectsRouteData().push<void>(context),
-        ),
+      ...flag.switchOn<List<QuickButton>>(
+        RemoteConfigKeys.isFunchEnabled,
+        onTrue: () => [
+          QuickButton(
+            label: '科目検索',
+            iconUrl: null,
+            fallbackIcon: Icons.search,
+            onPressed: () =>
+                const CourseSubjectsRouteData().push<void>(context),
+          ),
+        ],
+        onFalse: () => const [],
+      ),
       if (isAuthenticated)
         QuickButton(
           label: '休講・補講',

--- a/apps/dotto/lib/feature/debug/debug_screen.dart
+++ b/apps/dotto/lib/feature/debug/debug_screen.dart
@@ -24,10 +24,10 @@ final class DebugScreen extends HookConsumerWidget {
     final fcmToken = useFuture(
       useMemoized(() => FirebaseMessaging.instance.getToken()),
     );
-    final overrides = ref.watch(featureFlagNotifierProvider);
+    final overrides = ref.watch(flagOverridesProvider);
 
     Future<void> showFlagOverridePicker(Flag<bool> flag) async {
-      final notifier = ref.read(featureFlagNotifierProvider.notifier);
+      final notifier = ref.read(flagOverridesProvider.notifier);
       final override = overrides[flag.key];
       final remoteConfigValue = ref
           .read(featureFlagRepositoryProvider)

--- a/apps/dotto/lib/feature/debug/debug_screen.dart
+++ b/apps/dotto/lib/feature/debug/debug_screen.dart
@@ -1,6 +1,7 @@
-import 'package:dotto/controller/config_controller.dart';
-import 'package:dotto/domain/remote_config_keys.dart';
-import 'package:dotto/helper/remote_config_helper.dart';
+import 'package:dotto/controller/feature_flag_controller.dart';
+import 'package:dotto/foundation/flag.dart';
+import 'package:dotto/foundation/flags.dart';
+import 'package:dotto/repository/feature_flag_repository.dart';
 import 'package:firebase_app_check/firebase_app_check.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
@@ -23,61 +24,71 @@ final class DebugScreen extends HookConsumerWidget {
     final fcmToken = useFuture(
       useMemoized(() => FirebaseMessaging.instance.getToken()),
     );
-    final config = ref.watch(configProvider);
-    final configNotifier = ref.read(configProvider.notifier);
-    final isFunchEnabledOverride = configNotifier.isFunchEnabledOverride;
-    final remoteConfigIsFunchEnabled = ref
-        .read(remoteConfigHelperProvider)
-        .getBool(RemoteConfigKeys.isFunchEnabled);
+    final overrides = ref.watch(featureFlagNotifierProvider);
 
-    Future<void> showIsFunchEnabledOverridePicker() async {
+    Future<void> showFlagOverridePicker(Flag<bool> flag) async {
+      final notifier = ref.read(featureFlagNotifierProvider.notifier);
+      final override = overrides[flag.key];
+      final remoteConfigValue = ref
+          .read(featureFlagRepositoryProvider)
+          .get(flag);
+
       await showDialog<void>(
         context: context,
         builder: (dialogContext) => SimpleDialog(
-          title: const Text('isFunchEnabled Override'),
+          title: Text('${flag.description} Override'),
           children: [
             SimpleDialogOption(
               onPressed: () async {
                 Navigator.of(dialogContext).pop();
-                await configNotifier.setIsFunchEnabledOverride(value: null);
+                await notifier.setOverride(flag, value: null);
               },
               child: ListTile(
                 contentPadding: EdgeInsets.zero,
                 title: const Text('Use Remote Config'),
-                subtitle: Text('Remote Config: $remoteConfigIsFunchEnabled'),
-                trailing: isFunchEnabledOverride == null
-                    ? const Icon(Icons.check)
-                    : null,
+                subtitle: Text('Remote Config: $remoteConfigValue'),
+                trailing: override == null ? const Icon(Icons.check) : null,
               ),
             ),
             SimpleDialogOption(
               onPressed: () async {
                 Navigator.of(dialogContext).pop();
-                await configNotifier.setIsFunchEnabledOverride(value: true);
+                await notifier.setOverride(flag, value: true);
               },
               child: ListTile(
                 contentPadding: EdgeInsets.zero,
                 title: const Text('Force true'),
-                trailing: isFunchEnabledOverride ?? false
-                    ? const Icon(Icons.check)
-                    : null,
+                trailing: override == true ? const Icon(Icons.check) : null,
               ),
             ),
             SimpleDialogOption(
               onPressed: () async {
                 Navigator.of(dialogContext).pop();
-                await configNotifier.setIsFunchEnabledOverride(value: false);
+                await notifier.setOverride(flag, value: false);
               },
               child: ListTile(
                 contentPadding: EdgeInsets.zero,
                 title: const Text('Force false'),
-                trailing: isFunchEnabledOverride == false
-                    ? const Icon(Icons.check)
-                    : null,
+                trailing: override == false ? const Icon(Icons.check) : null,
               ),
             ),
           ],
         ),
+      );
+    }
+
+    Widget flagTile(Flag<Object> flag) {
+      final override = overrides[flag.key];
+      final effectiveValue = ref.watch(featureFlagProvider(flag));
+
+      return ListTile(
+        title: Text('${flag.description} Flag'),
+        subtitle: Text(switch (override) {
+          null => 'Use Remote Config',
+          _ => 'Forced: $override',
+        }),
+        trailing: Text('Effective: $effectiveValue'),
+        onTap: flag is Flag<bool> ? () => showFlagOverridePicker(flag) : null,
       );
     }
 
@@ -171,16 +182,7 @@ final class DebugScreen extends HookConsumerWidget {
             title: Text('Environment'),
             trailing: Text(appFlavor ?? 'Default'),
           ),
-          ListTile(
-            title: const Text('isFunchEnabled Override'),
-            subtitle: Text(switch (isFunchEnabledOverride) {
-              true => 'Forced: true',
-              false => 'Forced: false',
-              null => 'Use Remote Config ($remoteConfigIsFunchEnabled)',
-            }),
-            trailing: Text('Effective: ${config.isFunchEnabled}'),
-            onTap: showIsFunchEnabledOverridePicker,
-          ),
+          ...Flags.all.map(flagTile),
         ],
       ),
     );

--- a/apps/dotto/lib/feature/onboarding/onboarding_screen.dart
+++ b/apps/dotto/lib/feature/onboarding/onboarding_screen.dart
@@ -1,6 +1,7 @@
 import 'package:dotto/asset.dart';
-import 'package:dotto/controller/config_controller.dart';
+import 'package:dotto/controller/feature_flag_controller.dart';
 import 'package:dotto/feature/onboarding/domain/onboarding_page.dart';
+import 'package:dotto/foundation/flags.dart';
 import 'package:dotto_design_system/component/button.dart';
 import 'package:dotto_design_system/style/semantic_color.dart';
 import 'package:flutter/material.dart';
@@ -256,9 +257,7 @@ final class OnboardingScreen extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final isFunchEnabled = ref.watch(
-      configProvider.select((config) => config.isFunchEnabled),
-    );
+    final isFunchEnabled = ref.watch(featureFlagProvider(Flags.funch));
     final pages = OnboardingPage.pages(isFunchEnabled: isFunchEnabled);
     final pageController = usePageController();
     final currentPage = useState(0);

--- a/apps/dotto/lib/feature/onboarding/onboarding_screen.dart
+++ b/apps/dotto/lib/feature/onboarding/onboarding_screen.dart
@@ -1,14 +1,13 @@
 import 'package:dotto/asset.dart';
-import 'package:dotto/controller/feature_flag_controller.dart';
 import 'package:dotto/feature/onboarding/domain/onboarding_page.dart';
 import 'package:dotto/foundation/flags.dart';
+import 'package:dotto/foundation/use_flag.dart';
 import 'package:dotto_design_system/component/button.dart';
 import 'package:dotto_design_system/style/semantic_color.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
-import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-final class OnboardingScreen extends HookConsumerWidget {
+final class OnboardingScreen extends HookWidget {
   const OnboardingScreen({required this.onDismissed, super.key});
 
   final void Function() onDismissed;
@@ -256,8 +255,8 @@ final class OnboardingScreen extends HookConsumerWidget {
   }
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final isFunchEnabled = ref.watch(featureFlagProvider(Flags.funch));
+  Widget build(BuildContext context) {
+    final isFunchEnabled = useFlag(Flags.funch);
     final pages = OnboardingPage.pages(isFunchEnabled: isFunchEnabled);
     final pageController = usePageController();
     final currentPage = useState(0);

--- a/apps/dotto/lib/feature/root/root_initialization_state.dart
+++ b/apps/dotto/lib/feature/root/root_initialization_state.dart
@@ -1,9 +1,11 @@
 import 'package:dotto/controller/config_controller.dart';
+import 'package:dotto/controller/feature_flag_controller.dart';
 import 'package:dotto/foundation/async_entity.dart';
 import 'package:dotto/foundation/async_entity_notifier.dart';
 import 'package:dotto/helper/logger.dart';
 import 'package:dotto/helper/notification_helper.dart';
 import 'package:dotto/helper/remote_config_helper.dart';
+import 'package:dotto/repository/feature_flag_repository.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'root_initialization_state.g.dart';
@@ -18,8 +20,11 @@ final class RootInitializationState extends _$RootInitializationState
   Future<bool> fetch() async {
     // Setup Remote Config
     await ref.read(remoteConfigHelperProvider).setup();
+    // Remote Configのfetch結果をConfigとFeatureFlagへ反映
+    ref.read(configProvider.notifier).refresh();
+    ref.invalidate(featureFlagRepositoryProvider);
     // Load local debug overrides
-    await ref.read(configProvider.notifier).loadOverrides();
+    await ref.read(featureFlagNotifierProvider.notifier).loadOverrides();
     // Setup Notification
     await ref.read(notificationHelperProvider).setupInteractedMessage();
     // Setup Logger

--- a/apps/dotto/lib/feature/root/root_initialization_state.dart
+++ b/apps/dotto/lib/feature/root/root_initialization_state.dart
@@ -24,7 +24,7 @@ final class RootInitializationState extends _$RootInitializationState
     ref.read(configProvider.notifier).refresh();
     ref.invalidate(featureFlagRepositoryProvider);
     // Load local debug overrides
-    await ref.read(featureFlagNotifierProvider.notifier).loadOverrides();
+    await ref.read(flagOverridesProvider.notifier).loadOverrides();
     // Setup Notification
     await ref.read(notificationHelperProvider).setupInteractedMessage();
     // Setup Logger

--- a/apps/dotto/lib/feature/root/root_screen.dart
+++ b/apps/dotto/lib/feature/root/root_screen.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
 
-import 'package:dotto/controller/config_controller.dart';
+import 'package:dotto/controller/feature_flag_controller.dart';
 import 'package:dotto/controller/notification_status_controller.dart';
 import 'package:dotto/domain/notification_alert_status.dart';
 import 'package:dotto/domain/tab_item.dart';
@@ -11,6 +11,7 @@ import 'package:dotto/feature/root/root_app_tutorial_state.dart';
 import 'package:dotto/feature/root/root_app_version.dart';
 import 'package:dotto/feature/root/root_app_version_state.dart';
 import 'package:dotto/feature/root/root_initialization_state.dart';
+import 'package:dotto/foundation/flags.dart';
 import 'package:dotto/foundation/screen_container.dart';
 import 'package:dotto/foundation/screen_states.dart';
 import 'package:dotto/helper/firebase_auth_provider.dart';
@@ -305,9 +306,7 @@ final class RootScreen extends HookConsumerWidget {
     final initialization = ref.watch(rootInitializationStateProvider);
     final appTutorial = ref.watch(rootAppTutorialStateProvider);
     final appVersion = ref.watch(rootAppVersionStateProvider);
-    final isFunchEnabled = ref.watch(
-      configProvider.select((config) => config.isFunchEnabled),
-    );
+    final isFunchEnabled = ref.watch(featureFlagProvider(Flags.funch));
     final activeTabs = _activeTabs(isFunchEnabled: isFunchEnabled);
 
     return ScreenContainer(

--- a/apps/dotto/lib/feature/root/root_screen.dart
+++ b/apps/dotto/lib/feature/root/root_screen.dart
@@ -1,6 +1,5 @@
 import 'dart:io';
 
-import 'package:dotto/controller/feature_flag_controller.dart';
 import 'package:dotto/controller/notification_status_controller.dart';
 import 'package:dotto/domain/notification_alert_status.dart';
 import 'package:dotto/domain/tab_item.dart';
@@ -14,6 +13,7 @@ import 'package:dotto/feature/root/root_initialization_state.dart';
 import 'package:dotto/foundation/flags.dart';
 import 'package:dotto/foundation/screen_container.dart';
 import 'package:dotto/foundation/screen_states.dart';
+import 'package:dotto/foundation/use_flag.dart';
 import 'package:dotto/helper/firebase_auth_provider.dart';
 import 'package:dotto/helper/firebase_messaging_provider.dart';
 import 'package:dotto/helper/logger.dart';
@@ -306,7 +306,7 @@ final class RootScreen extends HookConsumerWidget {
     final initialization = ref.watch(rootInitializationStateProvider);
     final appTutorial = ref.watch(rootAppTutorialStateProvider);
     final appVersion = ref.watch(rootAppVersionStateProvider);
-    final isFunchEnabled = ref.watch(featureFlagProvider(Flags.funch));
+    final isFunchEnabled = useFlag(Flags.funch);
     final activeTabs = _activeTabs(isFunchEnabled: isFunchEnabled);
 
     return ScreenContainer(

--- a/apps/dotto/lib/foundation/flag.dart
+++ b/apps/dotto/lib/foundation/flag.dart
@@ -1,0 +1,11 @@
+final class Flag<T> {
+  const Flag({
+    required this.key,
+    required this.description,
+    required this.defaultValue,
+  });
+
+  final String key;
+  final String description;
+  final T defaultValue;
+}

--- a/apps/dotto/lib/foundation/flags.dart
+++ b/apps/dotto/lib/foundation/flags.dart
@@ -1,0 +1,13 @@
+import 'package:dotto/foundation/flag.dart';
+
+abstract final class Flags {
+  /// Funch feature flag
+  static const funch = Flag<bool>(
+    key: 'is_funch_enabled',
+    description: 'Funch',
+    defaultValue: false,
+  );
+
+  /// Debug画面の一覧表示用。新しいフラグを追加したらここにも追記する。
+  static const List<Flag<Object>> all = [funch];
+}

--- a/apps/dotto/lib/foundation/use_flag.dart
+++ b/apps/dotto/lib/foundation/use_flag.dart
@@ -1,25 +1,29 @@
-import 'package:dotto/helper/remote_config_helper.dart';
+import 'package:dotto/controller/feature_flag_controller.dart';
+import 'package:dotto/foundation/flag.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-/// Remote Config の Bool 値で値を出し分けるための Hook。
+/// FeatureFlagの値で出し分けるためのHook。
+///
+/// 値は [featureFlagProvider] を参照するため、Debug用overrideも反映される。
 ///
 /// `switch` は Dart の予約語のため、メソッド名は [FlagSwitcher.switchOn] とする。
 FlagSwitcher useFlag(WidgetRef ref) {
-  final helper = ref.watch(remoteConfigHelperProvider);
-  return useMemoized(() => FlagSwitcher._(helper), [helper]);
+  return useMemoized(() => FlagSwitcher._(ref), [ref]);
 }
 
 final class FlagSwitcher {
-  const FlagSwitcher._(this._helper);
+  const FlagSwitcher._(this._ref);
 
-  final RemoteConfigHelper _helper;
+  final WidgetRef _ref;
 
-  T switchOn<T>(
-    String key, {
-    required T Function() onTrue,
-    required T Function() onFalse,
+  T get<T>(Flag<T> flag) => _ref.watch(featureFlagProvider(flag));
+
+  R switchOn<R>(
+    Flag<bool> flag, {
+    required R Function() onTrue,
+    required R Function() onFalse,
   }) {
-    return _helper.getBool(key) ? onTrue() : onFalse();
+    return get(flag) ? onTrue() : onFalse();
   }
 }

--- a/apps/dotto/lib/foundation/use_flag.dart
+++ b/apps/dotto/lib/foundation/use_flag.dart
@@ -3,27 +3,20 @@ import 'package:dotto/foundation/flag.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-/// FeatureFlagの値で出し分けるためのHook。
+/// FeatureFlagの値を返すHook。
 ///
 /// 値は [featureFlagProvider] を参照するため、Debug用overrideも反映される。
-///
-/// `switch` は Dart の予約語のため、メソッド名は [FlagSwitcher.switchOn] とする。
-FlagSwitcher useFlag(WidgetRef ref) {
-  return useMemoized(() => FlagSwitcher._(ref), [ref]);
-}
-
-final class FlagSwitcher {
-  const FlagSwitcher._(this._ref);
-
-  final WidgetRef _ref;
-
-  T get<T>(Flag<T> flag) => _ref.watch(featureFlagProvider(flag));
-
-  R switchOn<R>(
-    Flag<bool> flag, {
-    required R Function() onTrue,
-    required R Function() onFalse,
-  }) {
-    return get(flag) ? onTrue() : onFalse();
-  }
+/// [WidgetRef] を必要としないため、HookWidgetからも利用できる。
+T useFlag<T>(Flag<T> flag) {
+  final container = ProviderScope.containerOf(useContext());
+  final value = useState(container.read(featureFlagProvider(flag)));
+  useEffect(() {
+    final subscription = container.listen(
+      featureFlagProvider(flag),
+      (_, next) => value.value = next,
+      fireImmediately: true,
+    );
+    return subscription.close;
+  }, [container, flag]);
+  return value.value;
 }

--- a/apps/dotto/lib/foundation/use_flag.dart
+++ b/apps/dotto/lib/foundation/use_flag.dart
@@ -1,0 +1,25 @@
+import 'package:dotto/helper/remote_config_helper.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+/// Remote Config の Bool 値で値を出し分けるための Hook。
+///
+/// `switch` は Dart の予約語のため、メソッド名は [FlagSwitcher.switchOn] とする。
+FlagSwitcher useFlag(WidgetRef ref) {
+  final helper = ref.watch(remoteConfigHelperProvider);
+  return useMemoized(() => FlagSwitcher._(helper), [helper]);
+}
+
+final class FlagSwitcher {
+  const FlagSwitcher._(this._helper);
+
+  final RemoteConfigHelper _helper;
+
+  T switchOn<T>(
+    String key, {
+    required T Function() onTrue,
+    required T Function() onFalse,
+  }) {
+    return _helper.getBool(key) ? onTrue() : onFalse();
+  }
+}

--- a/apps/dotto/lib/helper/remote_config_helper.dart
+++ b/apps/dotto/lib/helper/remote_config_helper.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:dotto/domain/remote_config_keys.dart';
+import 'package:dotto/foundation/flags.dart';
 import 'package:firebase_remote_config/firebase_remote_config.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -37,43 +38,23 @@ final class _RemoteConfigHelperImpl implements RemoteConfigHelper {
       );
     }
 
-    if (kDebugMode) {
-      await FirebaseRemoteConfig.instance.setDefaults(const {
-        RemoteConfigKeys.isFunchEnabled: false,
-        RemoteConfigKeys.validAppVersion: '0.0.0',
-        RemoteConfigKeys.latestAppVersion: '0.0.0',
-        RemoteConfigKeys.isUnderMaintenance: false,
-        RemoteConfigKeys.feedbackFormUrl: 'https://forms.gle/ruo8iBxLMmvScNMFA',
-        RemoteConfigKeys.appStorePageUrl: 'https://fun-dotto.github.io',
-        RemoteConfigKeys.officialCalendarPdfUrl:
-            'https://fun-dotto.github.io/files/official_calendar_2026.pdf',
-        RemoteConfigKeys.timetable1PdfUrl:
-            'https://fun-dotto.github.io/files/timetable_2026_1.pdf',
-        RemoteConfigKeys.timetable2PdfUrl:
-            'https://fun-dotto.github.io/files/timetable_2026_2.pdf',
-        RemoteConfigKeys.breakingAnnouncement: '',
-        RemoteConfigKeys.dottoWebUrl: 'https://dotto.web.app',
-        RemoteConfigKeys.macSupportDeskUrl: 'https://dotto.web.app/mac',
-      });
-    } else {
-      await FirebaseRemoteConfig.instance.setDefaults(const {
-        RemoteConfigKeys.isFunchEnabled: false,
-        RemoteConfigKeys.validAppVersion: '0.0.0',
-        RemoteConfigKeys.latestAppVersion: '0.0.0',
-        RemoteConfigKeys.isUnderMaintenance: false,
-        RemoteConfigKeys.feedbackFormUrl: 'https://forms.gle/ruo8iBxLMmvScNMFA',
-        RemoteConfigKeys.appStorePageUrl: 'https://fun-dotto.github.io',
-        RemoteConfigKeys.officialCalendarPdfUrl:
-            'https://fun-dotto.github.io/files/official_calendar_2026.pdf',
-        RemoteConfigKeys.timetable1PdfUrl:
-            'https://fun-dotto.github.io/files/timetable_2026_1.pdf',
-        RemoteConfigKeys.timetable2PdfUrl:
-            'https://fun-dotto.github.io/files/timetable_2026_2.pdf',
-        RemoteConfigKeys.breakingAnnouncement: '',
-        RemoteConfigKeys.dottoWebUrl: 'https://dotto.web.app',
-        RemoteConfigKeys.macSupportDeskUrl: 'https://dotto.web.app/mac',
-      });
-    }
+    await FirebaseRemoteConfig.instance.setDefaults({
+      for (final flag in Flags.all) flag.key: flag.defaultValue,
+      RemoteConfigKeys.validAppVersion: '0.0.0',
+      RemoteConfigKeys.latestAppVersion: '0.0.0',
+      RemoteConfigKeys.isUnderMaintenance: false,
+      RemoteConfigKeys.feedbackFormUrl: 'https://forms.gle/ruo8iBxLMmvScNMFA',
+      RemoteConfigKeys.appStorePageUrl: 'https://fun-dotto.github.io',
+      RemoteConfigKeys.officialCalendarPdfUrl:
+          'https://fun-dotto.github.io/files/official_calendar_2026.pdf',
+      RemoteConfigKeys.timetable1PdfUrl:
+          'https://fun-dotto.github.io/files/timetable_2026_1.pdf',
+      RemoteConfigKeys.timetable2PdfUrl:
+          'https://fun-dotto.github.io/files/timetable_2026_2.pdf',
+      RemoteConfigKeys.breakingAnnouncement: '',
+      RemoteConfigKeys.dottoWebUrl: 'https://dotto.web.app',
+      RemoteConfigKeys.macSupportDeskUrl: 'https://dotto.web.app/mac',
+    });
 
     await FirebaseRemoteConfig.instance.fetchAndActivate();
   }

--- a/apps/dotto/lib/repository/feature_flag_repository.dart
+++ b/apps/dotto/lib/repository/feature_flag_repository.dart
@@ -1,0 +1,26 @@
+import 'package:dotto/foundation/flag.dart';
+import 'package:dotto/helper/remote_config_helper.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'feature_flag_repository.g.dart';
+
+@Riverpod(keepAlive: true)
+FeatureFlagRepository featureFlagRepository(Ref ref) =>
+    FeatureFlagRepository(ref.watch(remoteConfigHelperProvider));
+
+/// Remote Config から [Flag] の値を型安全に取得する。
+final class FeatureFlagRepository {
+  const FeatureFlagRepository(this._remoteConfigHelper);
+
+  final RemoteConfigHelper _remoteConfigHelper;
+
+  T get<T>(Flag<T> flag) {
+    return switch (flag) {
+      Flag<bool>() => _remoteConfigHelper.getBool(flag.key) as T,
+      Flag<int>() => _remoteConfigHelper.getInt(flag.key) as T,
+      Flag<double>() => _remoteConfigHelper.getDouble(flag.key) as T,
+      Flag<String>() => _remoteConfigHelper.getString(flag.key) as T,
+      _ => flag.defaultValue,
+    };
+  }
+}

--- a/apps/dotto/lib/repository/flag_override_store.dart
+++ b/apps/dotto/lib/repository/flag_override_store.dart
@@ -1,0 +1,49 @@
+import 'package:dotto/foundation/flag.dart';
+import 'package:dotto/foundation/flags.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+part 'flag_override_store.g.dart';
+
+@Riverpod(keepAlive: true)
+FlagOverrideStore flagOverrideStore(Ref ref) => const FlagOverrideStore();
+
+/// Debug用のFeatureFlag overrideをSharedPreferencesへ永続化する。
+///
+/// 現状はbool型のフラグのみ対応する。
+final class FlagOverrideStore {
+  const FlagOverrideStore();
+
+  /// 旧実装 (ConfigNotifier) が使用していたfunch専用のキー。
+  static const _legacyIsFunchEnabledOverrideKey = 'isFunchEnabledOverride';
+
+  static String _prefsKey(Flag<Object> flag) => 'flag_override_${flag.key}';
+
+  /// 保存済みのoverrideをフラグのkeyをキーとするMapで読み込む。
+  Future<Map<String, Object?>> load(List<Flag<Object>> flags) async {
+    final prefs = await SharedPreferences.getInstance();
+    await _migrateLegacyKey(prefs);
+
+    return {
+      for (final flag in flags)
+        if (prefs.get(_prefsKey(flag)) case final Object value) flag.key: value,
+    };
+  }
+
+  Future<void> set(Flag<Object> flag, {required bool? value}) async {
+    final prefs = await SharedPreferences.getInstance();
+    if (value == null) {
+      await prefs.remove(_prefsKey(flag));
+    } else {
+      await prefs.setBool(_prefsKey(flag), value);
+    }
+  }
+
+  Future<void> _migrateLegacyKey(SharedPreferences prefs) async {
+    final legacyValue = prefs.getBool(_legacyIsFunchEnabledOverrideKey);
+    if (legacyValue == null) return;
+
+    await prefs.setBool(_prefsKey(Flags.funch), legacyValue);
+    await prefs.remove(_legacyIsFunchEnabledOverrideKey);
+  }
+}


### PR DESCRIPTION
# 変更点

<!--
変更内容を分かりやすく記載する
-->

- Feature flagを一元管理できる仕組みを導入
  - WidgetからはuseFlag hookで呼び出す

<!--以下はUI差分がある場合のみコメントアウトをはずして記述>
<!--
# UI 差分

|           Before           |           After            |
| :------------------------: | :------------------------: |
| <img src="" width="200" /> | <img src="" width="200" /> |
-->
