### PR TITLE
Renovateのグループ設定と保留ルールを見直し

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -118,14 +118,17 @@
       ]
     },
     {
+      "description": "win32 / geolocator_linux の制約で lockstep 更新が必要なため、メジャーも含めて1つのPRにまとめる",
       "groupName": "plus plugins",
       "matchManagers": [
         "pub"
       ],
       "matchPackageNames": [
+        "geolocator",
         "package_info_plus",
         "share_plus"
-      ]
+      ],
+      "separateMajorMinor": false
     },
     {
       "groupName": "riverpod",
@@ -226,17 +229,6 @@
       ]
     },
     {
-      "description": "Keep geolocator updates with package_info_plus when transitive plugin constraints move together",
-      "groupName": "geolocator",
-      "matchManagers": [
-        "pub"
-      ],
-      "matchPackageNames": [
-        "geolocator",
-        "package_info_plus"
-      ]
-    },
-    {
       "description": "Keep Melos updates with CLI-related tooling when shared transitive constraints move together",
       "groupName": "melos toolchain",
       "matchManagers": [
@@ -246,6 +238,27 @@
         "flutter_launcher_icons",
         "melos"
       ]
+    },
+    {
+      "description": "melos >=7.8.2 は cli_util ^0.5.0 を要求し、flutter_launcher_icons (cli_util ^0.4.1) と競合するため保留",
+      "matchManagers": [
+        "pub"
+      ],
+      "matchPackageNames": [
+        "melos"
+      ],
+      "allowedVersions": "<7.8.2"
+    },
+    {
+      "description": "built_value(_generator) >=8.12.6 は analyzer ^13 を要求し、riverpod_generator (analyzer ^12) と競合するため保留",
+      "matchManagers": [
+        "pub"
+      ],
+      "matchPackageNames": [
+        "built_value",
+        "built_value_generator"
+      ],
+      "allowedVersions": "<8.12.6"
     },
     {
       "description": "intl is pinned by flutter_localizations and must wait for a Flutter SDK update",


### PR DESCRIPTION
# 変更点

<!--
変更内容を分かりやすく記載する
-->

- `geolocator` / `package_info_plus` / `share_plus` を1つの `plus plugins` グループに統合し、`separateMajorMinor: false` を設定
  - `geolocator_linux` が `package_info_plus ^10` を、`share_plus` / `package_info_plus` が同一メジャーの `win32` を要求するため、3つを lockstep で更新しないと version solving が失敗する（#635 / #641 / #642 のCI失敗の原因）
- `melos` を `<7.8.2` に保留
  - `melos >=7.8.2` は `cli_util ^0.5.0` を要求し、`flutter_launcher_icons` 最新版（`cli_util ^0.4.1`）と競合するため（#636 / #640 のCI失敗の原因）
- `built_value` / `built_value_generator` を `<8.12.6` に保留
  - `built_value_generator 8.12.6` は `analyzer ^13` を要求し、`riverpod_generator`（`analyzer ^12`）と競合するため（#634 のCI失敗の原因）

保留ルールは、競合先パッケージが新しい制約に対応した時点で削除する想定です。

なお #638 (dio 5.10.0) は設定ではなくコード修正が必要です（`DioExceptionType.transformTimeout` が `domain_error.dart` の switch で未処理）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)