### PR TITLE
意見箱のFeature Flagを追加

### DIFF
--- a/apps/dotto/lib/foundation/flags.dart
+++ b/apps/dotto/lib/foundation/flags.dart
@@ -8,6 +8,13 @@ abstract final class Flags {
     defaultValue: false,
   );
 
+  /// Opinion box feature flag
+  static const opinionBox = Flag<bool>(
+    key: 'is_opinion_box_enabled',
+    description: 'Opinion Box',
+    defaultValue: false,
+  );
+
   /// Debug画面の一覧表示用。新しいフラグを追加したらここにも追記する。
-  static const List<Flag<Object>> all = [funch];
+  static const List<Flag<Object>> all = [funch, opinionBox];
 }

--- a/apps/dotto/lib/foundation/flags.dart
+++ b/apps/dotto/lib/foundation/flags.dart
@@ -11,7 +11,7 @@ abstract final class Flags {
   /// Opinion box feature flag
   static const opinionBox = Flag<bool>(
     key: 'is_opinion_box_enabled',
-    description: 'Opinion Box',
+    description: '意見箱',
     defaultValue: false,
   );
 


### PR DESCRIPTION
# やったこと
- [x] `apps/dotto/lib/foundation/flags.dart` に `opinionBox`フラグを追加
- [x] Debug画面の一覧表示用のリストに`opinionBox` を追記
# コメント
- マイルストーンに該当するものがなさそうだったため、未設定です
- PRの書き方の修正点があれば教えて欲しいです