### PR TITLE
Add commit info to Firebase App Distribution release notes

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -19,3 +19,11 @@ def append_ota_result(platform_label:, flavor:, release:)
   File.write(result_file, "#{line}\n")
   UI.message("Wrote OTA result to #{result_file}")
 end
+
+# OTA配信のリリースノート(コミットハッシュ + コミットメッセージ)を組み立てる共通ヘルパー。
+# Firebase App Distribution の release_notes に渡し、どのコミットのビルドかをテスターが確認できるようにする。
+def ota_release_notes
+  commit_hash = sh("git", "rev-parse", "--short", "HEAD", log: false).strip
+  commit_message = sh("git", "log", "-1", "--pretty=%B", log: false).strip
+  "#{commit_hash}: #{commit_message}"
+end

--- a/fastlane/android/Fastfile
+++ b/fastlane/android/Fastfile
@@ -59,6 +59,7 @@ platform :android do
       android_artifact_type: "APK",
       android_artifact_path: "apps/dotto/build/app/outputs/flutter-apk/app-#{flavor}-release.apk",
       groups: ENV["FIREBASE_APP_DISTRIBUTION_GROUPS"],
+      release_notes: ota_release_notes,
     )
   end
 

--- a/fastlane/ios/Fastfile
+++ b/fastlane/ios/Fastfile
@@ -213,6 +213,7 @@ platform :ios do
       app: firebase_app_id,
       ipa_path: "build/dotto-#{flavor}.ipa",
       groups: ENV["FIREBASE_APP_DISTRIBUTION_GROUPS"],
+      release_notes: ota_release_notes,
     )
     append_ota_result(platform_label: "iOS", flavor: flavor, release: release)
   end
@@ -230,6 +231,7 @@ platform :ios do
       app: firebase_app_id,
       ipa_path: "build/dotto-#{flavor}.ipa",
       groups: ENV["FIREBASE_APP_DISTRIBUTION_GROUPS"],
+      release_notes: ota_release_notes,
     )
     reset_build_number
     append_ota_result(platform_label: "iOS", flavor: flavor, release: release)
@@ -248,6 +250,7 @@ platform :ios do
         app: ENV[config[:firebase_app_id_env]],
         ipa_path: "build/dotto-#{flavor}.ipa",
         groups: ENV["FIREBASE_APP_DISTRIBUTION_GROUPS"],
+        release_notes: ota_release_notes,
       )
       reset_build_number
       [flavor, release]


### PR DESCRIPTION
# 変更点

- 新しいヘルパー関数 `ota_release_notes` を追加し、現在のコミットハッシュとコミットメッセージを組み合わせたリリースノートを生成
- iOS と Android の Firebase App Distribution 配信処理に `release_notes` パラメータを追加し、テスターがどのコミットのビルドかを確認できるように改善

## 詳細

Firebase App Distribution へのビルド配信時に、テスターが配信されたビルドの由来を明確に把握できるよう、コミットハッシュとコミットメッセージをリリースノートに含めるようにしました。

- `fastlane/Fastfile`: `ota_release_notes` ヘルパー関数を実装
- `fastlane/ios/Fastfile`: 3箇所の Firebase App Distribution 呼び出しに `release_notes` を追加
- `fastlane/android/Fastfile`: Firebase App Distribution 呼び出しに `release_notes` を追加

リリースノートのフォーマット: `{commit_hash}: {commit_message}`

https://claude.ai/code/session_01B2RBEHMntNYnZXyTHxWKE6