### PR TITLE
意見箱ボタンにログ機能を追加

### DIFF
--- a/apps/dotto/lib/feature/course/course_screen.dart
+++ b/apps/dotto/lib/feature/course/course_screen.dart
@@ -163,8 +163,17 @@ final class CourseScreen extends HookConsumerWidget {
           label: '大学ポスト',
           iconUrl: null,
           fallbackIcon: Icons.send_rounded,
-          onPressed: () =>
-              _launchQuickLink(context, url: opinionBoxUrl, label: '大学ポスト'),
+          onPressed: () async {
+            await logger.logEvent(.opinionBoxButtonTapped);
+            if (!context.mounted) {
+              return;
+            }
+            await _launchQuickLink(
+              context,
+              url: opinionBoxUrl,
+              label: '大学ポスト',
+            );
+          },
         ),
     ];
 

--- a/apps/dotto/lib/feature/course/course_screen.dart
+++ b/apps/dotto/lib/feature/course/course_screen.dart
@@ -168,11 +168,7 @@ final class CourseScreen extends HookConsumerWidget {
             if (!context.mounted) {
               return;
             }
-            await _launchQuickLink(
-              context,
-              url: opinionBoxUrl,
-              label: '大学ポスト',
-            );
+            await _launchQuickLink(context, url: opinionBoxUrl, label: '大学ポスト');
           },
         ),
     ];

--- a/apps/dotto/lib/foundation/config/remote_configs.dart
+++ b/apps/dotto/lib/foundation/config/remote_configs.dart
@@ -115,7 +115,7 @@ abstract final class RemoteConfigs {
     getValue: _getString,
   );
 
-  /// 意見箱フォームURL。
+  /// 意見箱フォーム URL
   static const opinionBoxUrl = RemoteConfig<String>(
     key: 'opinion_box_url',
     defaultValue: 'https://forms.gle/Y5xh3mNH1YptocSu7',

--- a/apps/dotto/lib/foundation/config/remote_configs.dart
+++ b/apps/dotto/lib/foundation/config/remote_configs.dart
@@ -115,7 +115,7 @@ abstract final class RemoteConfigs {
     getValue: _getString,
   );
 
-  /// 意見箱フォーム URL
+  /// 意見箱フォームURL。
   static const opinionBoxUrl = RemoteConfig<String>(
     key: 'opinion_box_url',
     defaultValue: 'https://forms.gle/Y5xh3mNH1YptocSu7',

--- a/apps/dotto/lib/foundation/log/analytics_event_key.dart
+++ b/apps/dotto/lib/foundation/log/analytics_event_key.dart
@@ -1,6 +1,7 @@
 enum AnalyticsEventKey {
   dottoWebButtonTapped('dotto_web_button_tapped'),
-  macSupportButtonTapped('mac_support_button_tapped');
+  macSupportButtonTapped('mac_support_button_tapped'),
+  opinionBoxButtonTapped('opinion_box_button_tapped');
 
   const AnalyticsEventKey(this.value);
 


### PR DESCRIPTION
# 概要
- 意見箱ボタンにMacサポートのボタン同様にタップ時のログを追加
# やったこと
- [x] 意見箱ボタンにタップ時のログを追加
- [x] Remote Config周辺、意見箱のコメント表現を統一