### PR TITLE
Renovateの依存解決失敗を修正

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -141,48 +141,6 @@
       "minimumReleaseAge": "7 days"
     },
     {
-      "groupName": "riverpod",
-      "matchManagers": [
-        "pub"
-      ],
-      "matchPackageNames": [
-        "flutter_riverpod",
-        "hooks_riverpod",
-        "riverpod_annotation",
-        "riverpod_generator"
-      ]
-    },
-    {
-      "groupName": "freezed",
-      "matchManagers": [
-        "pub"
-      ],
-      "matchPackageNames": [
-        "freezed",
-        "freezed_annotation"
-      ]
-    },
-    {
-      "groupName": "json serialization",
-      "matchManagers": [
-        "pub"
-      ],
-      "matchPackageNames": [
-        "json_annotation",
-        "json_serializable"
-      ]
-    },
-    {
-      "groupName": "go router",
-      "matchManagers": [
-        "pub"
-      ],
-      "matchPackageNames": [
-        "go_router",
-        "go_router_builder"
-      ]
-    },
-    {
       "groupName": "one of",
       "matchManagers": [
         "pub"
@@ -193,17 +151,6 @@
       ],
       "separateMajorMinor": false,
       "minimumReleaseAge": "7 days"
-    },
-    {
-      "groupName": "widgetbook",
-      "matchManagers": [
-        "pub"
-      ],
-      "matchPackageNames": [
-        "widgetbook",
-        "widgetbook_annotation",
-        "widgetbook_generator"
-      ]
     },
     {
       "groupName": "sqflite",
@@ -218,7 +165,7 @@
       "minimumReleaseAge": "7 days"
     },
     {
-      "description": "Keep analyzer-constrained Dart dev tools in the same update PR",
+      "description": "コード生成系は workspace 全体で単一の analyzer に解決されるため、ジェネレータとその annotation / runtime を1つのPRにまとめる。ファミリ単位のグループを別に定義すると、後勝ちでこのグループに吸い上げられて lockstep が壊れるため統合している",
       "groupName": "dart analyzer toolchain",
       "matchManagers": [
         "pub"
@@ -227,9 +174,10 @@
         "build_runner",
         "built_value",
         "built_value_generator",
+        "flutter_riverpod",
         "freezed",
         "freezed_annotation",
-        "flutter_riverpod",
+        "go_router",
         "go_router_builder",
         "hooks_riverpod",
         "json_annotation",
@@ -238,9 +186,12 @@
         "riverpod_annotation",
         "riverpod_generator",
         "test",
+        "widgetbook",
         "widgetbook_annotation",
         "widgetbook_generator"
-      ]
+      ],
+      "separateMajorMinor": false,
+      "minimumReleaseAge": "7 days"
     },
     {
       "description": "Keep Melos updates with CLI-related tooling when shared transitive constraints move together",
@@ -266,15 +217,102 @@
       "allowedVersions": "<7.8.2"
     },
     {
-      "description": "built_value(_generator) >=8.12.6 は analyzer ^13 を要求し、riverpod_generator (analyzer ^12) と競合するため保留",
+      "description": "analyzer 9 系に固定するための上限。freezed の安定版が analyzer >=9 <11、riverpod_generator 4.0.3 が analyzer ^9 を要求し、riverpod_generator は次の安定版 4.0.4 で analyzer ^12 へ飛ぶため、コード生成系全体を analyzer 9 系に揃える必要がある。freezed 4 系の安定版(analyzer ^13)が出たら、riverpod_generator 4.0.6 / build_runner 2.15.2 / built_value_generator 8.12.6 / json_serializable 6.14.0 / mockito 5.7.0 / test 1.31.2 とまとめて上限を撤廃する",
       "matchManagers": [
         "pub"
       ],
       "matchPackageNames": [
-        "built_value",
+        "build_runner"
+      ],
+      "allowedVersions": "<2.15.2"
+    },
+    {
+      "description": "built_value_generator 8.12.3 以降は analyzer >=10 を要求するため保留 (analyzer 9 系固定)",
+      "matchManagers": [
+        "pub"
+      ],
+      "matchPackageNames": [
         "built_value_generator"
       ],
-      "allowedVersions": "<8.12.6"
+      "allowedVersions": "<8.12.3"
+    },
+    {
+      "description": "built_value_generator が built_value <8.13.0 を要求するため保留",
+      "matchManagers": [
+        "pub"
+      ],
+      "matchPackageNames": [
+        "built_value"
+      ],
+      "allowedVersions": "<8.13.0"
+    },
+    {
+      "description": "json_serializable 6.13.1 以降は analyzer >=10 を要求するため保留 (analyzer 9 系固定)。json_annotation は json_serializable 6.13.0 が >=4.11.0 <4.12.0 を要求するため連動して保留",
+      "matchManagers": [
+        "pub"
+      ],
+      "matchPackageNames": [
+        "json_serializable"
+      ],
+      "allowedVersions": "<6.13.1"
+    },
+    {
+      "matchManagers": [
+        "pub"
+      ],
+      "matchPackageNames": [
+        "json_annotation"
+      ],
+      "allowedVersions": "<4.12.0"
+    },
+    {
+      "description": "mockito 5.6.5 以降は analyzer ^13 を要求するため保留 (analyzer 9 系固定)",
+      "matchManagers": [
+        "pub"
+      ],
+      "matchPackageNames": [
+        "mockito"
+      ],
+      "allowedVersions": "<5.6.5"
+    },
+    {
+      "description": "test 1.31.1 以降は test_api >=0.7.12 を要求するが、Flutter SDK 3.44.6 の flutter_test は test_api 0.7.11 を厳密指定するため保留。Flutter SDK を上げるまで解除できない (1.31.2 は analyzer >=13 も要求する)",
+      "matchManagers": [
+        "pub"
+      ],
+      "matchPackageNames": [
+        "test"
+      ],
+      "allowedVersions": "<1.31.1"
+    },
+    {
+      "description": "riverpod_generator 4.0.4 以降は analyzer ^12 を要求するため保留 (analyzer 9 系固定)。riverpod_annotation / flutter_riverpod / hooks_riverpod は riverpod_generator 4.0.3 が riverpod_annotation 4.0.2 を、riverpod_annotation 4.0.2 が riverpod 3.2.1 を厳密指定するため連動して保留",
+      "matchManagers": [
+        "pub"
+      ],
+      "matchPackageNames": [
+        "riverpod_generator"
+      ],
+      "allowedVersions": "<4.0.4"
+    },
+    {
+      "matchManagers": [
+        "pub"
+      ],
+      "matchPackageNames": [
+        "riverpod_annotation"
+      ],
+      "allowedVersions": "<4.0.3"
+    },
+    {
+      "matchManagers": [
+        "pub"
+      ],
+      "matchPackageNames": [
+        "flutter_riverpod",
+        "hooks_riverpod"
+      ],
+      "allowedVersions": "<3.3.2"
     },
     {
       "description": "intl is pinned by flutter_localizations and must wait for a Flutter SDK update",

--- a/renovate.json
+++ b/renovate.json
@@ -11,15 +11,7 @@
     "before 4:00am on Wednesday",
     "before 4:00am on Friday"
   ],
-  "major": {
-    "minimumReleaseAge": "14 days"
-  },
-  "minor": {
-    "minimumReleaseAge": "7 days"
-  },
-  "patch": {
-    "minimumReleaseAge": "7 days"
-  },
+  "minimumReleaseAge": "7 days",
   "lockFileMaintenance": {
     "enabled": true,
     "automerge": true,
@@ -38,6 +30,20 @@
       "skipArtifactsUpdate": false
     },
     {
+      "description": "pub のビルドメタデータ(+N)を新しいバージョンとして扱う。既定の npm versioning は semver 仕様どおり +N を無視するため、firebase_app_check 0.4.5+2 のような更新が検出されず、同一ファミリの他パッケージだけが上がって依存解決に失敗する",
+      "matchManagers": [
+        "pub"
+      ],
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(?:-(?<prerelease>[^+]+))?(?:\\+(?<build>\\d+)(?:\\.(?<revision>\\d+))?)?$"
+    },
+    {
+      "description": "メジャー更新は既定で14日待つ。ロックステップ更新が必要なグループでは後続ルールで7日に揃える",
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "minimumReleaseAge": "14 days"
+    },
+    {
       "matchManagers": [
         "mise"
       ],
@@ -98,6 +104,7 @@
       ]
     },
     {
+      "description": "FlutterFire は *_platform_interface のメジャーが本体のパッチと同時にリリースされるため、メジャー/マイナーを分離せず待機日数も揃えて1つのPRにまとめる",
       "groupName": "firebase",
       "matchManagers": [
         "pub"
@@ -115,7 +122,9 @@
         "cloud_firestore",
         "firebase_auth_platform_interface",
         "firebase_core_platform_interface"
-      ]
+      ],
+      "separateMajorMinor": false,
+      "minimumReleaseAge": "7 days"
     },
     {
       "description": "win32 / geolocator_linux の制約で lockstep 更新が必要なため、メジャーも含めて1つのPRにまとめる",
@@ -128,7 +137,8 @@
         "package_info_plus",
         "share_plus"
       ],
-      "separateMajorMinor": false
+      "separateMajorMinor": false,
+      "minimumReleaseAge": "7 days"
     },
     {
       "groupName": "riverpod",
@@ -180,7 +190,9 @@
       "matchPackageNames": [
         "one_of",
         "one_of_serializer"
-      ]
+      ],
+      "separateMajorMinor": false,
+      "minimumReleaseAge": "7 days"
     },
     {
       "groupName": "widgetbook",
@@ -201,7 +213,9 @@
       "matchPackageNames": [
         "sqflite",
         "sqflite_common"
-      ]
+      ],
+      "separateMajorMinor": false,
+      "minimumReleaseAge": "7 days"
     },
     {
       "description": "Keep analyzer-constrained Dart dev tools in the same update PR",
@@ -237,7 +251,9 @@
       "matchPackageNames": [
         "flutter_launcher_icons",
         "melos"
-      ]
+      ],
+      "separateMajorMinor": false,
+      "minimumReleaseAge": "7 days"
     },
     {
       "description": "melos >=7.8.2 は cli_util ^0.5.0 を要求し、flutter_launcher_icons (cli_util ^0.4.1) と競合するため保留",


### PR DESCRIPTION
# 変更点

Renovate の PR ([#648](https://github.com/fun-dotto/app/pull/648) / [#654](https://github.com/fun-dotto/app/pull/654)) が依存解決に失敗していたため、`renovate.json` を修正した。

## 失敗の原因

**#648 (dart analyzer toolchain)**

```
Because test >=1.31.2 depends on analyzer >=13.0.0 <15.0.0 and
built_value_generator 8.12.5 depends on analyzer >=10.0.0 <13.0.0, ...
```

workspace 全体が単一の analyzer に解決されるのに、グループ内に異なる analyzer 世代を要求するバージョンが混在していた。実際の天井は analyzer 9 系で、`freezed` の安定版最新 3.2.5 が `analyzer >=9 <11`、`riverpod_generator` 4.0.3 が `analyzer ^9`（次の安定版 4.0.4 で `^12` へ飛ぶ）を要求するため、現状は analyzer 9 系から動かせない。既存の `built_value(_generator) <8.12.6` という上限は、理由・値ともに実態とずれていた（8.12.3 の時点で analyzer `^10` を要求している）。

**#654 (firebase)**

```
firebase_storage 13.4.5 depends on firebase_core_platform_interface ^8.0.0
So, because dotto depends on firebase_core_platform_interface 7.1.0, ...
```

原因が 2 つ重なっていた。

1. `firebase_core_platform_interface` 7.1.0 → 8.0.0 はメジャー更新のため `separateMajorMinor` の既定値により別ブランチへ分離され、本体のパッチだけが上がっていた。さらに `major.minimumReleaseAge: 14 days` によって分離先が保留され続けていた。
2. `firebase_app_check` が `0.4.5` のまま残っていた。最新は `0.4.5+2` だが、Renovate の pub は datasource が npm versioning を使うため、semver 仕様どおりビルドメタデータ `+N` を順序比較で無視し、更新候補として検出されない。この 1 つが残ると `firebase_core_platform_interface ^7.1.0` を要求し続けて解決不能になる。

## 修正内容

- pub に regex versioning を設定し、ビルドメタデータ `+N` を新しいバージョンとして扱えるようにした
- firebase / plus plugins / one of / sqflite / melos toolchain の各グループに `separateMajorMinor: false` と一律 7 日の `minimumReleaseAge` を設定した
- メジャーの待機日数（14 日）を `major` オブジェクトから `packageRules` へ移し、後勝ちでグループ側が上書きできるようにした
- riverpod / freezed / json serialization / go router / widgetbook の各グループを `dart analyzer toolchain` へ統合した（後勝ちで `go_router` と `go_router_builder`、`widgetbook` と `widgetbook_generator` が別 PR に分断されていたため）
- analyzer 9 系に揃えるための上限を各パッケージへ設定した
  - `build_runner <2.15.2` / `built_value_generator <8.12.3` / `json_serializable <6.13.1` / `mockito <5.6.5` / `riverpod_generator <4.0.4` … analyzer 10 以降を要求するため
  - `json_annotation <4.12.0` / `riverpod_annotation <4.0.3` / `flutter_riverpod, hooks_riverpod <3.3.2` / `built_value <8.13.0` … 上記の厳密指定に連動するため
  - `test <1.31.1` … analyzer ではなく、Flutter SDK 3.44.6 の `flutter_test` が `test_api 0.7.11` を厳密指定するため

## 確認内容

- pub.dev の pubspec メタデータ、`pubspec.lock`、Flutter SDK の `flutter_test/pubspec.yaml` を突き合わせ、修正後に各グループが提案するバージョンの組み合わせが analyzer 9.0.0 と両立することを確認した
  - analyzer toolchain グループの提案は build_runner 2.15.1 / built_value_generator 8.12.2 / go_router_builder 4.4.0 / mockito 5.6.4 のみになる
- `renovate.json` が妥当な JSON であること、および regex versioning のパターンが本リポジトリの固定バージョン 70 件すべてにマッチすることを確認した
- ローカルでの `flutter pub get` による実解決の検証は、実行環境から pub.dev への TLS 接続が遮断されており実施できていない。マージ後に #648 / #654 の rebase チェックボックスを付けて Renovate に再生成させることで確認したい

## 補足

`enabledManagers: ["pub"]` が指定されているため、mise 関連の 4 ルールは現状動作していない。今回の修正対象ではないため触っていない。
