### PR TITLE
Deployワークフローの本番ビルド失敗を修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -89,7 +89,7 @@ jobs:
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: production-aab
-          path: apps/dotto/build/app/outputs/bundle/release/app-release.aab
+          path: apps/dotto/build/app/outputs/bundle/storeRelease/app-store-release.aab
           if-no-files-found: error
           retention-days: 1
 
@@ -141,7 +141,7 @@ jobs:
       - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: production-aab
-          path: apps/dotto/build/app/outputs/bundle/release
+          path: apps/dotto/build/app/outputs/bundle/storeRelease
       - name: Upload to Google Play
         run: mise exec -- bundle exec fastlane android upload_google_play
 

--- a/apps/dotto/android/app/build.gradle.kts
+++ b/apps/dotto/android/app/build.gradle.kts
@@ -95,6 +95,13 @@ android {
             manifestPlaceholders["appName"] = "Dotto Prd"
             manifestPlaceholders["serviceHost"] = "dotto.furari.co"
         }
+        // ストア(Google Play)配信用。iOSのRunnerスキーム(Release構成)と対応し、
+        // applicationIdSuffixを付けずに素のapplicationIdで配信する
+        create("store") {
+            dimension = "default"
+            manifestPlaceholders["appName"] = "Dotto"
+            manifestPlaceholders["serviceHost"] = "dotto.furari.co"
+        }
     }
 
     buildFeatures {

--- a/apps/dotto/ios/Runner.xcodeproj/project.pbxproj
+++ b/apps/dotto/ios/Runner.xcodeproj/project.pbxproj
@@ -620,8 +620,8 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "Apple Distribution";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 64LEQXTB98;
@@ -636,7 +636,7 @@
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match Development jp.ac.fun.dotto";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore jp.ac.fun.dotto";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";

--- a/apps/dotto/lib/firebase_options_flavor.dart
+++ b/apps/dotto/lib/firebase_options_flavor.dart
@@ -8,8 +8,8 @@ import 'package:flutter/services.dart' show appFlavor;
 /// flavor に応じた [FirebaseOptions] を解決する。
 ///
 /// `flutter run --flavor dev` 等で起動すると [appFlavor] に flavor 名が入る。
-/// ストア版（flavor 指定なし）は `null` となり、`jp.ac.fun.dotto` の
-/// デフォルト設定（[default_options]）を使用する。
+/// ストア版は Android が `store`、iOS が flavor 指定なしの `null` となり、
+/// いずれも `jp.ac.fun.dotto` のデフォルト設定（[default_options]）を使用する。
 class FlavoredFirebaseOptions {
   const FlavoredFirebaseOptions._();
 

--- a/fastlane/android/Fastfile
+++ b/fastlane/android/Fastfile
@@ -109,9 +109,12 @@ platform :android do
     )
   end
 
-  ANDROID_PRODUCTION_AAB_PATH = "apps/dotto/build/app/outputs/bundle/release/app-release.aab"
+  ANDROID_PRODUCTION_FLAVOR = "store"
+  ANDROID_PRODUCTION_AAB_PATH = "apps/dotto/build/app/outputs/bundle/#{ANDROID_PRODUCTION_FLAVOR}Release/app-#{ANDROID_PRODUCTION_FLAVOR}-release.aab"
 
   # 本番(Google Play)向けの AAB をビルドする
+  # flavor を省略すると Gradle が全 flavor をビルドし、成果物が
+  # bundle/<flavor>Release/ 配下に出るため flutter が AAB を見つけられない
   def build_android_production(build_number)
     sh(
       'melos',
@@ -122,6 +125,8 @@ platform :android do
       'build',
       'appbundle',
       '--release',
+      "--flavor=#{ANDROID_PRODUCTION_FLAVOR}",
+      # store flavor は prd と同じ本番バックエンドを参照するため dart define も prd を使う
       '--dart-define-from-file=dart_defines/prd.json',
       "--build-number=#{build_number}",
     )


### PR DESCRIPTION
# 変更点

Deployワークフロー（[run #30360331050](https://github.com/fun-dotto/app/actions/runs/30360331050)）の Build iOS / Build Android が、それぞれ別の原因で失敗していたため修正します。

## Android: Google Play 配信用の `store` flavor を追加

- `flutter build appbundle` に `--flavor` を渡していなかったため、Gradle が `bundleRelease`（= dev/stg/prd の全 flavor）をビルドしていた
- 成果物は `bundle/<flavor>Release/app-<flavor>-release.aab` に出力されるが、flutter は `--flavor` 未指定時に `bundle/release/app-release.aab` しか探さないため `Gradle build failed to produce an .aab file` で失敗していた
- 既存の `prd` flavor は `applicationIdSuffix = ".prd"` を持ち Google Play のパッケージ名 `jp.ac.fun.dotto` と一致しないため、単に `--flavor prd` を渡すだけでは解決しない
- `applicationIdSuffix` を持たない `store` flavor を追加し、本番ビルドで明示的に指定するようにした。iOS の本番ビルドが Runner スキーム（Release 構成）でサフィックスなしの `jp.ac.fun.dotto` を出力するのと対応する
- Firebase 設定は `apps/dotto/android/app/google-services.json`（`jp.ac.fun.dotto` を含む）にフォールバックするため、flavor 専用ファイルの追加は不要
- アプリアイコンも `src/main/res` にフォールバックするため追加不要
- 副次的な効果として、全 flavor をビルドしなくなり Android のビルド時間が短縮される（失敗したジョブでは `bundleRelease` に 764 秒かかっていた）

## iOS: Release 構成の署名設定を配布用に修正

- Runner ターゲットの `Release` 構成が `match Development jp.ac.fun.dotto` と development 証明書を指定していた
- `build_production` レーンは `match_appstore_readonly` のみを実行するため Development プロファイルが未インストールで、archive 時に `No profile for team '64LEQXTB98' matching 'match Development jp.ac.fun.dotto' found` となっていた
- `Release` 構成は本番配信専用（ローカル開発と OTA は `Release-dev` / `Release-stg` / `Release-prd` を使用）のため、プロファイルを `match AppStore jp.ac.fun.dotto`、署名 ID を `Apple Distribution` に変更した

## 動作確認

- ローカルでは iOS の署名証明書と Android の keystore が無いため実ビルドは未検証。マージ後に Deploy ワークフローを再実行して確認する必要がある
- 静的な確認として Fastfile の Ruby 構文、`deploy.yml` の YAML 構文、`project.pbxproj` のフォーマットを検証済み

## 注意

- 2.2.0 の配信をやり直すには、このブランチを main にマージした後 `release/2.2.0` へ取り込む必要がある
- `flutter build ipa` と fastlane の `build_app` が二重に archive している問題（iOS ビルド時間がほぼ倍になる）は本 PR の対象外。別途対応を検討したい

