### PR TITLE
TestFlightへのアップロード失敗を修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -104,7 +104,8 @@ jobs:
   ios-upload:
     name: Upload to TestFlight
     needs: ready-to-upload
-    runs-on: ubuntu-latest
+    # TestFlight へのアップロードには Xcode 同梱の iTMSTransporter が必要なため macOS で実行する
+    runs-on: macos-26
     timeout-minutes: 60
     env:
       APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
@@ -112,6 +113,8 @@ jobs:
       APP_STORE_CONNECT_API_KEY_CONTENT_BASE64: ${{ secrets.APP_STORE_CONNECT_API_KEY_CONTENT_BASE64 }}
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - name: Setup Xcode
+        run: xcodes select
       - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           project_id: swift2023groupc


### PR DESCRIPTION
# 変更点

Deployワークフロー（[run #30367777825](https://github.com/fun-dotto/app/actions/runs/30367777825)）で、ビルドは成功したものの Upload to TestFlight / Upload to Google Play の両方が失敗したため、コード側で解決できる TestFlight 側を修正します。

## TestFlight: アップロードを macOS ランナーで実行する

- `ios-upload` ジョブは `ubuntu-latest` で動いていたが、fastlane の `upload_to_testflight`（pilot）はバイナリ転送に iTMSTransporter を使用する
- macOS / Windows 以外では `FastlaneCore::Helper.itms_path` が空文字列を返すため、`JavaTransporterExecutor#execute` の `FileUtils.cd("")` が `Errno::ENOENT` で失敗していた

```
[!] No such file or directory @ dir_chdir0 -
    fastlane_core/lib/fastlane_core/itunes_transporter.rb:728:in 'FastlaneCore::JavaTransporterExecutor#execute'
```

- Xcode 同梱の Transporter を利用できるよう `ios-upload` を `macos-26`（ビルドジョブと同じ）へ移し、`.xcode-version` に従って Xcode を選択する `Setup Xcode` ステップを追加した

## Google Play: 本 PR では対応できない（署名鍵の不一致）

`upload_to_play_store` が以下のエラーで失敗しています。

```
Google Api Error: Invalid request - The Android App Bundle was signed with the wrong key.
  Found:    SHA1: F6:E7:7B:3D:92:F4:D1:70:30:37:9D:78:88:D5:6B:E4:87:50:7A:17
  Expected: SHA1: 95:BE:B4:13:00:BF:49:C6:F0:D2:16:D4:27:E8:E2:59:38:07:72:70
```

成果物（`production-aab`）をダウンロードして署名証明書を確認したところ、AAB は debug 鍵ではなく実際のリリース鍵で正しく署名されていました。

```
所有者: CN=Dotto, OU=Dotto, O=Future University Hakodate, L=Hakodate, ST=Hokkaido, C=JP
有効期間の開始日: Fri Jun 19 21:57:37 JST 2026
SHA1: F6:E7:7B:3D:92:F4:D1:70:30:37:9D:78:88:D5:6B:E4:87:50:7A:17
```

つまり Gradle の署名設定は意図どおり動作しており、`ANDROID_KEYSTORE_BASE64` の鍵が Google Play に登録済みのアップロード鍵（`95:BE:...`）と別物であることが原因です。証明書の作成日が 2026-06-19 であることから、CI 用に新規生成された鍵が Play Console 未登録のままになっていると考えられます。

リポジトリの変更では解決できないため、以下のいずれかの対応が必要です。

1. Play に登録済みの元のアップロード鍵を `ANDROID_KEYSTORE_BASE64` / `ANDROID_KEYSTORE_PASSWORD` / `ANDROID_RELEASE_KEY_ALIAS` に設定し直す
2. Play Console でアップロード鍵の再登録を申請し、現在の鍵に差し替える（証明書は `keytool -export -rfc -keystore release.jks -alias <alias> -file upload_certificate.pem` で書き出す）

## 動作確認

- ローカルからは TestFlight へのアップロードを検証できないため、マージ後に Deploy ワークフローを再実行して確認する必要がある
- 静的な確認として `deploy.yml` の YAML 構文と `ios-upload` ジョブ定義を検証済み
- なお `upload_to_testflight` の失敗が `Ready to upload` より後段であることから、iOS の IPA 自体は正しく生成・署名されている（App Store Connect API の認証も成功しログに `Ready to upload new build to TestFlight (App: 6471561803)` が出ている）

## 注意

- 2.2.0 の配信をやり直すには、`release/2.2.0` へも取り込む必要がある


### 追加調査: キーストア内の鍵の内訳

OTA 用 APK（`ota-apk-prd`）の署名証明書も確認したところ、`ANDROID_KEYSTORE_BASE64` の 1 つのキーストアに少なくとも 2 つの鍵が入っており、そのどちらも Play の期待値と一致しないことが分かりました。`deploy.yml` は `ANDROID_RELEASE_KEY_ALIAS`、`deploy-ota.yml` は `ANDROID_OTA_KEY_ALIAS` と、同じキーストアから別のエイリアスを引いています。

| 用途 | エイリアス Secret | 証明書 SHA-1 |
| --- | --- | --- |
| 本番 AAB（今回の失敗） | `ANDROID_RELEASE_KEY_ALIAS` | `F6:E7:7B:3D:92:F4:D1:70:30:37:9D:78:88:D5:6B:E4:87:50:7A:17` |
| OTA APK (prd) | `ANDROID_OTA_KEY_ALIAS` | `4B:05:8D:55:81:C7:47:3B:53:6B:A9:CC:8C:49:72:CC:5B:0A:D7:DF` |
| Google Play が要求 | — | `95:BE:B4:13:00:BF:49:C6:F0:D2:16:D4:27:E8:E2:59:38:07:72:70` |

DN はいずれも `CN=Dotto, OU=Dotto, O=Future University Hakodate, L=Hakodate, ST=Hokkaido, C=JP` です。

次の手順でキーストア内の全エイリアスを列挙し、`95:BE:B4:13:...` を持つエイリアスがあるか確認するのが切り分けになります。

```bash
keytool -J-Duser.language=en -list -v -keystore release.jks | grep -E "Alias name|SHA1:"
```

- 該当エイリアスがある場合: `ANDROID_RELEASE_KEY_ALIAS` をそのエイリアス名に差し替えるだけで解決する（エイリアスの指定ミス）
- 無い場合: Play のアップロード鍵はこのキーストアに含まれていない。過去リリースを署名した別のキーストアに差し替えるか、Play Console でアップロード鍵の再登録を申請する

Play のトラックには既存リリースがあります（初回実行時に `google_play_track_version_codes` から version code 54 を取得し `--build-number=55` になっていた）。過去のリリースは `95:BE:B4:13:...` の鍵で署名されているため、その鍵の所在を確認するのが最短です。
