### PR TITLE
GitHub ActionsをコミットSHAで固定

### DIFF
--- a/.github/actions/setup-ci/action.yml
+++ b/.github/actions/setup-ci/action.yml
@@ -5,14 +5,14 @@ runs:
   using: composite
   steps:
     - name: Cache Dart dependencies
-      uses: actions/cache@v5
+      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
       with:
         path: ~/.pub-cache
         key: ${{ runner.os }}-pub-${{ hashFiles('mise.toml', 'pubspec.lock', 'pubspec.yaml', 'apps/**/pubspec.yaml', 'packages/**/pubspec.yaml') }}
         restore-keys: |
           ${{ runner.os }}-pub-
 
-    - uses: jdx/mise-action@v4
+    - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
       with:
         github_token: ${{ github.token }}
         cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v6
-      - uses: google-github-actions/auth@v3
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           project_id: swift2023groupc
           workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
@@ -52,8 +52,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v6
-      - uses: google-github-actions/auth@v3
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           project_id: swift2023groupc
           workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}

--- a/.github/workflows/deploy-ota.yml
+++ b/.github/workflows/deploy-ota.yml
@@ -41,17 +41,17 @@ jobs:
       FIREBASE_APP_ID_IOS_STG: ${{ secrets.FIREBASE_APP_ID_IOS_STG }}
       FIREBASE_APP_ID_IOS_PRD: ${{ secrets.FIREBASE_APP_ID_IOS_PRD }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Setup Xcode
         run: xcodes select
-      - uses: google-github-actions/auth@v3
+      - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           project_id: swift2023groupc
           workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
       - name: Generate token to access certificates repository
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ vars.MATCH_GIT_APP_ID }}
           private-key: ${{ secrets.MATCH_GIT_APP_PRIVATE_KEY }}
@@ -64,7 +64,7 @@ jobs:
       - uses: ./.github/actions/setup-ci
       - name: Build iOS OTA (${{ matrix.flavor }})
         run: mise exec -- bundle exec fastlane ios build_ota_flavor flavor:${{ matrix.flavor }}
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: ota-ipa-${{ matrix.flavor }}
           path: build/dotto-${{ matrix.flavor }}.ipa
@@ -84,8 +84,8 @@ jobs:
       FIREBASE_APP_ID_ANDROID_STG: ${{ secrets.FIREBASE_APP_ID_ANDROID_STG }}
       FIREBASE_APP_ID_ANDROID_PRD: ${{ secrets.FIREBASE_APP_ID_ANDROID_PRD }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: google-github-actions/auth@v3
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           project_id: swift2023groupc
           workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
@@ -108,7 +108,7 @@ jobs:
           EOF
       - name: Build Android OTA (${{ matrix.flavor }})
         run: mise exec -- bundle exec fastlane android build_ota_flavor flavor:${{ matrix.flavor }}
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: ota-apk-${{ matrix.flavor }}
           path: apps/dotto/build/app/outputs/flutter-apk/app-${{ matrix.flavor }}-release.apk
@@ -137,20 +137,20 @@ jobs:
       FIREBASE_APP_ID_IOS_STG: ${{ secrets.FIREBASE_APP_ID_IOS_STG }}
       FIREBASE_APP_ID_IOS_PRD: ${{ secrets.FIREBASE_APP_ID_IOS_PRD }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: google-github-actions/auth@v3
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           project_id: swift2023groupc
           workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
       - uses: ./.github/actions/setup-ci
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: ota-ipa-${{ matrix.flavor }}
           path: build
       - name: Distribute iOS OTA (${{ matrix.flavor }})
         run: mise exec -- bundle exec fastlane ios distribute_ota_flavor flavor:${{ matrix.flavor }}
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: ota-result-ios-${{ matrix.flavor }}
           path: ${{ env.OTA_RESULT_FILE }}
@@ -170,20 +170,20 @@ jobs:
       FIREBASE_APP_ID_ANDROID_STG: ${{ secrets.FIREBASE_APP_ID_ANDROID_STG }}
       FIREBASE_APP_ID_ANDROID_PRD: ${{ secrets.FIREBASE_APP_ID_ANDROID_PRD }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: google-github-actions/auth@v3
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           project_id: swift2023groupc
           workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
       - uses: ./.github/actions/setup-ci
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: ota-apk-${{ matrix.flavor }}
           path: apps/dotto/build/app/outputs/flutter-apk
       - name: Distribute Android OTA (${{ matrix.flavor }})
         run: mise exec -- bundle exec fastlane android distribute_ota_flavor flavor:${{ matrix.flavor }}
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: ota-result-android-${{ matrix.flavor }}
           path: ${{ env.OTA_RESULT_FILE }}
@@ -196,7 +196,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           path: ota-results
           pattern: ota-result-*


### PR DESCRIPTION
# 変更点

タグ参照のまま残っていた GitHub Actions をコミット SHA で固定します。`deploy.yml` と `update-pubspec-lock.yml` は既に固定済みでしたが、それ以外の 3 ファイル（計 22 箇所）が未対応でした。

| ファイル | 対象 |
| --- | --- |
| `.github/actions/setup-ci/action.yml` | `actions/cache` / `jdx/mise-action` |
| `.github/workflows/ci.yml` | `actions/checkout` ×2 / `google-github-actions/auth` ×2 |
| `.github/workflows/deploy-ota.yml` | `actions/checkout` ×4 / `google-github-actions/auth` ×4 / `actions/create-github-app-token` / `actions/upload-artifact` ×5 / `actions/download-artifact` ×3 |

Renovate が更新できるよう、バージョンタグはコメントで併記しています。

## 固定したバージョン

| アクション | バージョン | SHA |
| --- | --- | --- |
| `actions/cache` | v5.1.0 | `caa296126883cff596d87d8935842f9db880ef25` |
| `jdx/mise-action` | v4.2.0 | `e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d` |
| `actions/checkout` | v6.1.0 | `d23441a48e516b6c34aea4fa41551a30e30af803` |
| `google-github-actions/auth` | v3.0.0 | `7c6bc770dae815cd3e89ee6cdf493a5fab2cc093` |
| `actions/create-github-app-token` | v3.2.0 | `bcd2ba49218906704ab6c1aa796996da409d3eb1` |
| `actions/upload-artifact` | v6.0.0 | `b7c566a772e6b6bfb58ed0dc250532a479d7789f` |
| `actions/download-artifact` | v7.0.0 | `37930b1c2abaa49bbe596cd826c3c89aef350131` |

バージョンの選び方には次の方針を採りました。

- **原則、既にリポジトリ内で固定済みのバージョンに揃える**。固定作業に暗黙のバージョンアップを混ぜず、リポジトリ内で同一アクションのバージョンが分裂しないようにするため。上記のうち `actions/cache` 以外は既存の固定値と完全に一致している
- `actions/cache` のみリポジトリ内に固定実績がないため、`@v5` が指す最新の v5 系（v5.1.0、2026-06-26 公開）を採用した。v6 系も存在するが、固定作業でメジャーバージョンを上げないよう v5 系に留めている
- `jdx/mise-action` は最新が v4.2.3 だが、`update-pubspec-lock.yml` が固定している v4.2.0 に合わせた
- いずれも公開から 3 日以上経過した安定版

各 SHA は `gh api repos/<owner>/<repo>/commits/<tag>` で解決し、既存の固定値と一致することを確認しています。

## 動作確認

- `.github/` 配下に残るタグ参照が無いことを確認（ローカルアクション `./.github/actions/setup-ci` を除く）
- 変更した 3 ファイルの YAML 構文を検証
- SHA の解決結果が既存の固定値と一致することを確認

## 別途対応が必要な点

`renovate.json` の `enabledManagers` が `["pub"]` のみになっているため、**現状 Renovate は `github-actions` マネージャーを実行していません**。バージョンタグをコメントで併記しても、このままでは固定した SHA が自動更新されず塩漬けになります。実際に Renovate がアクションや `mise.toml` の更新 PR を作成した履歴はありませんでした。

あわせて、`renovate.json` には `matchManagers: ["mise"]` の packageRules が複数定義されていますが、同じ理由で現在は機能していません（flutter / ruby のマイナー・メジャー抑止、java のメジャー抑止など）。

`enabledManagers` に `"github-actions"`（および意図があれば `"mise"`）を追加するのが妥当だと考えますが、Renovate の PR 発生量が変わるため本 PR では触れていません。
